### PR TITLE
Revise RFC1, 2 & 3 to replace status-code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,5 @@
     "editor.detectIndentation": false,
     "editor.tabSize": 4,
     "markdown.extension.list.indentationSize": "inherit",
-    "markdown.extension.toc.githubCompatibility": true,
+    "markdown.extension.toc.githubCompatibility": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,13 @@
     "editor.detectIndentation": false,
     "editor.tabSize": 4,
     "markdown.extension.list.indentationSize": "inherit",
+    "spellright.language": [
+        "en_US"
+    ],
+    "spellright.documentTypes": [
+        "markdown",
+        "latex",
+        "plaintext"
+    ],
     "markdown.extension.toc.githubCompatibility": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
     "editor.tabSize": 4,
     "markdown.extension.list.indentationSize": "inherit",
     "spellright.language": [
-        "en_US"
+        "en_AU"
     ],
     "spellright.documentTypes": [
         "markdown",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,7 @@
         "latex",
         "plaintext"
     ],
-    "markdown.extension.toc.githubCompatibility": true
+    "markdown.extension.toc.githubCompatibility": true,
+    "tableformatter.markdown.tableEdgesType": "Normal",
+    "tableformatter.common.centerAlignedHeader": false
 }

--- a/RFC-001-BAM.md
+++ b/RFC-001-BAM.md
@@ -45,6 +45,9 @@
         - [Naming conventions](#naming-conventions)
     - [Connection errors / failure cases](#connection-errors--failure-cases)
         - [Malformed response](#malformed-response)
+- [Registry extensions](#registry-extensions)
+    - [List of request types](#list-of-request-types)
+    - [The section `ERROR frame types`](#the-section-error-frame-types)
 - [References](#references)
 
 ## Description
@@ -497,6 +500,17 @@ For requests, an `ERROR` frame with type `malformed-frame` can be sent back to t
 However, there are no response messages for responses.
 In this case, implementations should treat this as a *temporary* failure by logging the incident and ignoring the malformed response.
 Implementations should be able to receive further messages on the connection.
+
+## Registry extensions
+
+### List of request types
+
+This RFC adds a section "Request types" to track the list of available `type`s to be used for `REQUEST` frames.
+
+### The section `ERROR frame types`
+
+This RFC adds a section "ERROR frame types" to track the possbile types of ERROR frames.
+The types defined in section [ERROR frame](#possible-error-types) are added to this list.
 
 ## References
 

--- a/RFC-001-BAM.md
+++ b/RFC-001-BAM.md
@@ -46,8 +46,7 @@
     - [Connection errors / failure cases](#connection-errors--failure-cases)
         - [Malformed response](#malformed-response)
 - [Registry extensions](#registry-extensions)
-    - [List of request types](#list-of-request-types)
-    - [The section `ERROR frame types`](#the-section-error-frame-types)
+    - [List of frame types](#list-of-frame-types)
 - [References](#references)
 
 ## Description
@@ -503,14 +502,21 @@ Implementations should be able to receive further messages on the connection.
 
 ## Registry extensions
 
-### List of request types
+### List of frame types
 
-This RFC adds a section "Request types" to track the list of available `type`s to be used for `REQUEST` frames.
+This RFC adds a section "FRAME types" to track the list of available `type`s to be used for `FRAME`s.
+The following types are added to this list:
 
-### The section `ERROR frame types`
+- REQUEST/RESPONSE
+- ERROR
 
-This RFC adds a section "ERROR frame types" to track the possbile types of ERROR frames.
-The types defined in section [ERROR frame](#possible-error-types) are added to this list.
+For the `REQUEST` frame, the following `type`s are defined:
+
+- SWAP
+
+Each of the defined REQUEST `type`s should list the headers that can be used with this REQUEST.
+
+For the `ERROR` frame, the `type`s listed in the [ERROR frame](#possible-error-types) section are added as valid types.
 
 ## References
 

--- a/RFC-001-BAM.md
+++ b/RFC-001-BAM.md
@@ -223,7 +223,7 @@ Usually, this can be derived from the `REQUEST` that is sent by a node.
 ###### Body
 
 The structure of the `body` of a REQUEST is entirely up to the application protocol.
-Similar to HTTP, application protocols MAY include some kind of 'Content-Type' in the headers in order to describe the encoding of the body.
+Application protocols MAY include one or more headers indicating how the body should be parsed (similar to HTTP's `Content-Type` header).
 
 When designing an application protocol, it is common to overcome the question of whether a specific piece of data should be encoded as a header or be represented in the body.
 The rule of thumb here is that implementations should be able to parse all headers orthogonally.

--- a/RFC-001-BAM.md
+++ b/RFC-001-BAM.md
@@ -47,7 +47,6 @@
         - [Malformed response](#malformed-response)
 - [Registry extensions](#registry-extensions)
     - [List of frame types](#list-of-frame-types)
-- [References](#references)
 
 ## Description
 
@@ -521,7 +520,3 @@ For the `REQUEST` frame, the following `type`s are defined:
 Each of the defined REQUEST `type`s should list the headers that can be used with this REQUEST.
 
 For the `ERROR` frame, the `type`s listed in the [ERROR frame](#possible-error-types) section are added as valid types.
-
-## References
-
-- [1] : https://tools.ietf.org/html/rfc3117#section-3.3

--- a/RFC-001-BAM.md
+++ b/RFC-001-BAM.md
@@ -513,10 +513,6 @@ The following types are added to this list:
 - REQUEST/RESPONSE
 - ERROR
 
-For the `REQUEST` frame, the following `type`s are defined:
-
-- SWAP
-
 Each of the defined REQUEST `type`s should list the headers that can be used with this REQUEST.
 
 For the `ERROR` frame, the `type`s listed in the [ERROR frame](#possible-error-types) section are added as valid types.

--- a/RFC-001-BAM.md
+++ b/RFC-001-BAM.md
@@ -17,7 +17,7 @@
     - [Frames](#frames)
         - [Type](#type)
         - [Id](#id)
-    - [Different frame types](#different-frame-types)
+    - [Frame types](#frame-types)
         - [Notification](#notification)
         - [Request / Response](#request--response)
             - [Structure](#structure)
@@ -166,7 +166,7 @@ For example, a `RESPONSE` frame MUST use the `id` of the `REQUEST` frame it refe
 
 Ids MAY be skipped but MUST be ascending.
 
-### Different frame types
+### Frame types
 
 #### Notification
 

--- a/RFC-001-BAM.md
+++ b/RFC-001-BAM.md
@@ -214,7 +214,7 @@ If a node receives a header in the `MUST understand` variant in a `REQUEST` and 
 Headers encoded as `MAY ignore` are ok to be not understood.
 Nodes may simply ignore them as if they were not there.
 
-To avoid more complexity through additional messages, the spec doesn't define a concept for acknowledging successful processing of a `RESPONSE` to the sender.
+To avoid more complexity through additional messages, the spec doesn't define a concept for acknowledging processing of a `RESPONSE` to the sender.
 Thus, there is no way of signaling to the sender of a `RESPONSE` whether or not it was properly understood.
 Therefore, careful thought should be put into the design and use of the `MUST understand` variant of a header to make this failure case as rare as possible.
 In particular, nodes SHOULD NOT send a `RESPONSE` that contains a `MUST understand` header without them having confidence that the receiving node will understand it.

--- a/RFC-001-BAM.md
+++ b/RFC-001-BAM.md
@@ -341,9 +341,9 @@ Example:
 
 ```json
 {
-    "type": "REQUEST",
-    "id": 10,
-    "payload": {}
+  "type": "REQUEST",
+  "id": 10,
+  "payload": {}
 }
 ```
 
@@ -358,9 +358,9 @@ For the `REQUEST` frame, the `payload` looks like this:
 
 ```json
 {
-    "type": "...",
-    "headers": {},
-    "body": {},
+  "type": "...",
+  "headers": {},
+  "body": {},
 }
 ```
 
@@ -371,8 +371,8 @@ As noted above, responses don't have a `type`.
 
 ```json
 {
-    "headers": {},
-    "body": {},
+  "headers": {},
+  "body": {},
 }
 ```
 
@@ -386,10 +386,10 @@ Let's start off with an example:
 
 ```json
 "_alpha_ledger" : {
-    "value": "Bitcoin",
-    "parameters": {
-        "network": "mainnet"
-    }
+  "value": "Bitcoin",
+  "parameters": {
+    "network": "mainnet"
+  }
 }
 ```
 
@@ -415,15 +415,15 @@ Sometimes, headers only carry one particular value.
 For example:
 
 ```json
-"swap_protocol": {
-    "value": "COMIT-RFC-003"
+"protocol": {
+  "value": "my-protocol"
 }
 ```
 
 In cases like these, where there are no parameters, implementations can choose to use the compact representation which looks like this:
 
 ```json
-"swap_protocol": "COMIT-RFC-003"
+"protocol": "my-protocol"
 ```
 
 Implementations MUST be able to process compact representations.
@@ -435,7 +435,7 @@ The following is therefore invalid:
 
 ```json
 "invalid_header": {
-    "some_key": "foobar"
+  "some_key": "foobar"
 }
 ```
 
@@ -443,9 +443,9 @@ If a header needs an `object` to express its value, you should resort to the def
 
 ```json
 "valid_header": {
-    "value": {
-        "some_key": "foobar"
-    }
+  "value": {
+    "some_key": "foobar"
+  }
 }
 ```
 

--- a/RFC-001-BAM.md
+++ b/RFC-001-BAM.md
@@ -21,12 +21,14 @@
         - [Notification](#notification)
         - [Error](#error)
             - [Structure](#structure)
+                - [type](#type)
+                - [message](#message)
             - [Possible error types](#possible-error-types)
         - [Request / Response](#request--response)
             - [Structure](#structure-1)
-            - [Optional fields](#optional-fields)
-            - [Type](#type-1)
-            - [Headers](#headers)
+                - [Type](#type-1)
+                - [Headers](#headers)
+                - [Body](#body)
     - [Headers](#headers-1)
     - [JSON Encoding](#json-encoding)
         - [Frames](#frames-1)
@@ -178,11 +180,11 @@ It's `id` MUST refer to a previously received frame, like a `REQUEST` frame.
 
 `ERROR` frames carry the following payload:
 
-- type
+###### type
 
 A machine-friendly identifier for this type of error
 
-- message
+###### message
 
 A human-readable message giving more details about the error.
 Implementations MAY use this for logging purposes.
@@ -215,21 +217,18 @@ whereas a frame of type `RESPONSE` looks like this:
 - headers
 - body
 
-##### Optional fields
-
 With the exception of `type`, all of these are optional and MAY be omitted if they are empty and the underlying encoding allows this without introducing ambiguity.
 For example, the JSON encoding can easily handle that whereas a binary encoding may have a difficult time to omit certain fields.
 
-##### Type
+###### Type
 
 The field `type` in a request defines the semantics of the given request.
 Defining a particular request type usually comes with defining the headers which are usable within this request.
 
-##### Headers
+###### Headers
 
-`Headers` and `Body` are supposed to be used by an application protocol defined on top of `BAM`.
-Application protocols can be described by defining `REQUEST` types and with them, the semantics of certain headers and the body of a `REQUEST`.
-Similar to HTTP, application protocols MAY include some kind of 'Content-Type' in the headers in order to describe the encoding of the body.
+`Headers` are supposed to be used by an application protocol defined on top of `BAM`.
+Application protocols can be described by defining `REQUEST` types and with them, the semantics of certain headers of a `REQUEST`.
 
 In addition, headers also encode compatibility information.
 Each header is available in two variants:
@@ -246,6 +245,16 @@ Thus, there is no way of signaling to the sender of a `RESPONSE` whether or not 
 Therefore, careful thought should be put into the design of and use of the `MUST understand` variant of a header to make this failure case as rare as possible.
 In particular, nodes should never send a `RESPONSE` that contains a `MUST understand` header without them having confidence that the receiving node will understand it.
 Usually, this can be derived from the `REQUEST` that is sent by a node.
+
+###### Body
+
+The structure of the `body` of a REQUEST is entirely up to the application protocol that is defined through the REQUEST `type`.
+Similar to HTTP, application protocols MAY include some kind of 'Content-Type' in the headers in order to describe the encoding of the body.
+When designing an application protocol, it is common to overcome the question of whether a specific piece of data should be encoded as a header or be represented in the body.
+The rule of thumb here is that implementations should be able to parse all headers orthogonally.
+Hence, the structure/possible values of one header SHOULD NOT depend on those of other headers.
+All data that cannot be represented in that way can be put into the `body`.
+Implementations can then first parse the set of headers and from there determine, what the expected shape of the `body` is in order to continue parsing.
 
 ### Headers
 

--- a/RFC-001-BAM.md
+++ b/RFC-001-BAM.md
@@ -429,7 +429,7 @@ Let's start off with an example:
 In the above example:
 - `payment_method` is the header-key.
 - The underscore in the beginning denotes that this header MAY be ignored if not understood.
-Respectively, if the key does_not start with an underscore, the header is mandatory and MUST be understood by the node.
+Respectively, if the key does not start with an underscore, the header is mandatory and MUST be understood by the node.
 - `value` is the header-value (see [Headers - Requirement 2](#headers))
 - `parameters` encode the parameters of the header.
 

--- a/RFC-001-BAM.md
+++ b/RFC-001-BAM.md
@@ -19,18 +19,18 @@
         - [Id](#id)
     - [Different frame types](#different-frame-types)
         - [Notification](#notification)
-        - [Error](#error)
+        - [Request / Response](#request--response)
             - [Structure](#structure)
+                - [Type](#type-1)
+                - [Headers](#headers)
+                - [Body](#body)
+        - [Error](#error)
+            - [Structure](#structure-1)
                 - [type](#type)
                 - [details](#details)
             - [Possible error types](#possible-error-types)
             - [Error details](#error-details)
                 - [Details for `unknown-mandatory-header`](#details-for-unknown-mandatory-header)
-        - [Request / Response](#request--response)
-            - [Structure](#structure-1)
-                - [Type](#type-1)
-                - [Headers](#headers)
-                - [Body](#body)
     - [Headers](#headers-1)
     - [JSON Encoding](#json-encoding)
         - [Frames](#frames-1)
@@ -173,54 +173,6 @@ Ids MAY be skipped but MUST be ascending.
 
 > `NOTIFICATION` is a reserved type and may be specified at a later point.
 
-#### Error
-
-The `ERROR` frame is used to communicate failures between nodes at the communication level.
-They MUST NOT be used to communicate errors on the application level.
-Instead, `ERROR` frames are used for received `FRAME`s which cannot be parsed or are invalid.
-An `ERROR` frame cannot be sent pro-actively.
-Its `id` MUST match that of a previously received frame, like a `REQUEST` frame.
-
-##### Structure
-
-`ERROR` frames carry the following payload:
-
-###### type
-
-A machine-friendly identifier for this type of error.
-
-###### details
-
-An object which further describes this error.
-The shape depends on the `type` of the `ERROR` frame.
-
-##### Possible error types
-
-This RFC introduces the following ERROR frame types.
-Future RFCs MAY extend this list with new error types.
-
-| type | details |
-|---|---|
-| `unknown-frame-type` | None |
-| `malformed-frame` | None |
-| `unknown-request-type` | None |
-| `unknown-mandatory-header` | [See below](#details-for-unknown-mandatory-header) |
-
-##### Error details
-
-###### Details for `unknown-mandatory-header`
-
-The details object for the `unknown-mandatory-header` error is an object with a single key `header`.
-Its value is the key of the header that was marked as mandatory by the sender but was not understood by the receiver.
-
-For example:
-
-```json
-{
-  "header": "payment_method"
-}
-```
-
 #### Request / Response
 
 A request is a type of message that implies an answer.
@@ -279,6 +231,54 @@ The rule of thumb here is that implementations should be able to parse all heade
 Hence, the structure of one header SHOULD NOT depend on those of other headers.
 All data that cannot be represented in that way can be put into the `body`.
 Implementations can then first parse the set of headers to determine the expected shape of the `body`, in order to continue parsing.
+
+#### Error
+
+The `ERROR` frame is used to communicate failures between nodes at the communication level.
+They MUST NOT be used to communicate errors on the application level.
+Instead, `ERROR` frames are used for received `FRAME`s which cannot be parsed or are invalid.
+An `ERROR` frame cannot be sent pro-actively.
+Its `id` MUST match that of a previously received frame, like a `REQUEST` frame.
+
+##### Structure
+
+`ERROR` frames carry the following payload:
+
+###### type
+
+A machine-friendly identifier for this type of error.
+
+###### details
+
+An object which further describes this error.
+The shape depends on the `type` of the `ERROR` frame.
+
+##### Possible error types
+
+This RFC introduces the following ERROR frame types.
+Future RFCs MAY extend this list with new error types.
+
+| type | details |
+|---|---|
+| `unknown-frame-type` | None |
+| `malformed-frame` | None |
+| `unknown-request-type` | None |
+| `unknown-mandatory-header` | [See below](#details-for-unknown-mandatory-header) |
+
+##### Error details
+
+###### Details for `unknown-mandatory-header`
+
+The details object for the `unknown-mandatory-header` error is an object with a single key `header`.
+Its value is the key of the header that was marked as mandatory by the sender but was not understood by the receiver.
+
+For example:
+
+```json
+{
+  "header": "payment_method"
+}
+```
 
 ### Headers
 

--- a/RFC-001-BAM.md
+++ b/RFC-001-BAM.md
@@ -175,8 +175,9 @@ Ids MAY be skipped but MUST be ascending.
 
 #### Error
 
-The `ERROR` frame is used to communicate failures between nodes at the lowest level of this protocol.
-It is purely informational and is meant to facilitate debugging.
+The `ERROR` frame is used to communicate failures between nodes at the communication level.
+They MUST NOT be used to communicate errors on the application level.
+Instead, `ERROR` frames are used for received `FRAME`s which cannot be parsed or are invalid.
 An `ERROR` frame cannot be sent pro-actively.
 Its `id` MUST match that of a previously received frame, like a `REQUEST` frame.
 
@@ -194,6 +195,9 @@ An object which further describes this error.
 The shape depends on the `type` of the `ERROR` frame.
 
 ##### Possible error types
+
+This RFC introduces the following ERROR frame types.
+Future RFCs MAY extend this list with new error types.
 
 | type | details |
 |---|---|

--- a/RFC-001-BAM.md
+++ b/RFC-001-BAM.md
@@ -237,7 +237,7 @@ Implementations can then first parse the set of headers to determine the expecte
 The `ERROR` frame is used to communicate failures between nodes at the communication level.
 They MUST NOT be used to communicate errors on the application level.
 Instead, `ERROR` frames are used for received `FRAME`s which cannot be parsed or are invalid.
-An `ERROR` frame cannot be sent pro-actively.
+An `ERROR` frame can only be sent instead of reply message (e.g. `RESPONSE`).
 Its `id` MUST match that of a previously received frame, like a `REQUEST` frame.
 
 ##### Structure

--- a/RFC-001-BAM.md
+++ b/RFC-001-BAM.md
@@ -22,8 +22,10 @@
         - [Error](#error)
             - [Structure](#structure)
                 - [type](#type)
-                - [message](#message)
+                - [details](#details)
             - [Possible error types](#possible-error-types)
+            - [Error details](#error-details)
+                - [Details for `unknown-mandatory-header`](#details-for-unknown-mandatory-header)
         - [Request / Response](#request--response)
             - [Structure](#structure-1)
                 - [Type](#type-1)
@@ -184,19 +186,34 @@ Its `id` MUST match that of a previously received frame, like a `REQUEST` frame.
 
 A machine-friendly identifier for this type of error.
 
-###### message
+###### details
 
-A human-readable message giving more details about the error.
-Implementations MAY use this for logging purposes.
+An object which further describes this error.
+The shape depends on the `type` of the `ERROR` frame.
 
 ##### Possible error types
 
-The following types of `ERROR` frames are defined:
+| type | details |
+|---|---|
+| `unknown-frame-type` | None |
+| `malformed-frame` | None |
+| `unknown-request-type` | None |
+| `unknown-mandatory-header` | [See below](#details-for-unknown-mandatory-header) |
 
-- `unknown-frame-type`
-- `malformed-frame`
-- `unknown-request-type`
-- `unknown-mandatory-header`
+##### Error details
+
+###### Details for `unknown-mandatory-header`
+
+The details object for the `unknown-mandatory-header` error is an object with a single key `header`.
+Its value is the key of the header that was marked as mandatory by the sender but was not understood by the receiver.
+
+For example:
+
+```json
+{
+  "header": "payment_method"
+}
+```
 
 #### Request / Response
 

--- a/RFC-001-BAM.md
+++ b/RFC-001-BAM.md
@@ -158,7 +158,7 @@ This means the maximum allowed value is `4294967295`.
 Ids MUST NOT be reused for subsequent frames.
 
 A node should only assign `id`s to frames that are out-going and self-initiated, for example `REQUEST` frames.
-All frames that act as a reply to another frame MUST use the appriopriate `id` to establish the necessary context.
+All frames that act as a reply to another frame MUST use the `id` of the message they are replying to.
 For example, a `RESPONSE` frame MUST use the `id` of the `REQUEST` frame it refers to.
 
 Ids MAY be skipped but MUST be ascending.
@@ -171,10 +171,10 @@ Ids MAY be skipped but MUST be ascending.
 
 #### Error
 
-The `ERROR` frame is used to communicate failures between nodes on the lowest level of this protocol.
-It is purely informational and is meant to fascilitate debugging.
-An `ERROR` frame can not be sent pro-actively.
-It's `id` MUST refer to a previously received frame, like a `REQUEST` frame.
+The `ERROR` frame is used to communicate failures between nodes at the lowest level of this protocol.
+It is purely informational and is meant to facilitate debugging.
+An `ERROR` frame cannot be sent pro-actively.
+Its `id` MUST match that of a previously received frame, like a `REQUEST` frame.
 
 ##### Structure
 
@@ -182,7 +182,7 @@ It's `id` MUST refer to a previously received frame, like a `REQUEST` frame.
 
 ###### type
 
-A machine-friendly identifier for this type of error
+A machine-friendly identifier for this type of error.
 
 ###### message
 
@@ -202,7 +202,7 @@ The following types of `ERROR` frames are defined:
 
 A request is a type of message that implies an answer.
 Nodes MUST be prepared to receive a frame of type `RESPONSE` with the id used in the `REQUEST` frame.
-Alternatively to a `RESPONSE` frame, the other party MAY also send an `ERROR` frame.
+Alternatively to a `RESPONSE` frame, the other party MAY instead send an `ERROR` frame.
 
 ##### Structure
 
@@ -212,13 +212,13 @@ A frame of type `REQUEST` carries the following payload:
 - headers
 - body
 
-whereas a frame of type `RESPONSE` looks like this:
+Conversely, a frame of type `RESPONSE` looks like this:
 
 - headers
 - body
 
 With the exception of `type`, all of these are optional and MAY be omitted if they are empty and the underlying encoding allows this without introducing ambiguity.
-For example, the JSON encoding can easily handle that whereas a binary encoding may have a difficult time to omit certain fields.
+For example, the JSON encoding can easily handle that whereas a binary encoding may have a difficult time omitting certain fields.
 
 ###### Type
 
@@ -228,7 +228,7 @@ Defining a particular request type usually comes with defining the headers which
 ###### Headers
 
 `Headers` are supposed to be used by an application protocol defined on top of `BAM`.
-Application protocols can be described by defining `REQUEST` types and with them, the semantics of certain headers of a `REQUEST`.
+Application protocols can be described by defining `REQUEST` types and, with them, the semantics of certain headers of a `REQUEST`.
 
 In addition, headers also encode compatibility information.
 Each header is available in two variants:
@@ -240,21 +240,22 @@ If a node receives a header in the `MUST understand` variant in a `REQUEST` and 
 Headers encoded as `MAY ignore` are ok to be not understood.
 Nodes may simply ignore them as if they were not there.
 
-To avoid more complexity through additional messages, the spec doesn't define a concept of acknowledging successful processing of a `RESPONSE` to the sender.
+To avoid more complexity through additional messages, the spec doesn't define a concept for acknowledging successful processing of a `RESPONSE` to the sender.
 Thus, there is no way of signaling to the sender of a `RESPONSE` whether or not it was properly understood.
-Therefore, careful thought should be put into the design of and use of the `MUST understand` variant of a header to make this failure case as rare as possible.
-In particular, nodes should never send a `RESPONSE` that contains a `MUST understand` header without them having confidence that the receiving node will understand it.
+Therefore, careful thought should be put into the design and use of the `MUST understand` variant of a header to make this failure case as rare as possible.
+In particular, nodes SHOULD NOT send a `RESPONSE` that contains a `MUST understand` header without them having confidence that the receiving node will understand it.
 Usually, this can be derived from the `REQUEST` that is sent by a node.
 
 ###### Body
 
-The structure of the `body` of a REQUEST is entirely up to the application protocol that is defined through the REQUEST `type`.
+The structure of the `body` of a REQUEST is entirely up to the application protocol.
 Similar to HTTP, application protocols MAY include some kind of 'Content-Type' in the headers in order to describe the encoding of the body.
+
 When designing an application protocol, it is common to overcome the question of whether a specific piece of data should be encoded as a header or be represented in the body.
 The rule of thumb here is that implementations should be able to parse all headers orthogonally.
-Hence, the structure/possible values of one header SHOULD NOT depend on those of other headers.
+Hence, the structure of one header SHOULD NOT depend on those of other headers.
 All data that cannot be represented in that way can be put into the `body`.
-Implementations can then first parse the set of headers and from there determine, what the expected shape of the `body` is in order to continue parsing.
+Implementations can then first parse the set of headers to determine the expected shape of the `body`, in order to continue parsing.
 
 ### Headers
 
@@ -397,7 +398,7 @@ Let's start off with an example:
 "_payment_method" : {
   "value": "credit-card",
   "parameters": {
-    "provider": "visa",
+    "provider": "tenx",
     "number": "0000-0000-0000-0000"
   }
 }
@@ -449,7 +450,7 @@ The following is therefore invalid:
 }
 ```
 
-If a header needs an `object` to express its value, you should resort to the default representation to make it unambigous:
+If a header needs an `object` to express its value, you should resort to the default representation to make it unambiguous:
 
 ```json
 "valid_header": {

--- a/RFC-001-BAM.md
+++ b/RFC-001-BAM.md
@@ -394,16 +394,17 @@ This section defines how headers are encoded in the JSON-based text encoding.
 Let's start off with an example:
 
 ```json
-"_alpha_ledger" : {
-  "value": "Bitcoin",
+"_payment_method" : {
+  "value": "credit-card",
   "parameters": {
-    "network": "mainnet"
+    "provider": "visa",
+    "number": "0000-0000-0000-0000"
   }
 }
 ```
 
 In the above example:
-- `alpha_ledger` is the header-key.
+- `payment_method` is the header-key.
 - The underscore in the beginning denotes that this header MAY be ignored if not understood.
 Respectively, if the key does_not start with an underscore, the header is mandatory and MUST be understood by the node.
 - `value` is the header-value (see [Headers - Requirement 2](#headers))
@@ -424,15 +425,15 @@ Sometimes, headers only carry one particular value.
 For example:
 
 ```json
-"protocol": {
-  "value": "my-protocol"
+"payment_method": {
+  "value": "cash"
 }
 ```
 
 In cases like these, where there are no parameters, implementations can choose to use the compact representation which looks like this:
 
 ```json
-"protocol": "my-protocol"
+"payment_method": "cash"
 ```
 
 Implementations MUST be able to process compact representations.
@@ -463,9 +464,9 @@ If a header needs an `object` to express its value, you should resort to the def
 - Frame types should use all caps convention.
 For example, `REQUEST`.
 - Headers should use snake case convention.
-For example, `alpha_ledger`.
+For example, `payment_method`.
 - `REQUEST` types should use all caps convention as well.
-For example: `SWAP`.
+For example: `BUY`.
 
 ### Connection errors / failure cases
 

--- a/RFC-001-BAM.md
+++ b/RFC-001-BAM.md
@@ -228,7 +228,7 @@ Application protocols MAY include one or more headers indicating how the body sh
 When designing an application protocol, it is common to overcome the question of whether a specific piece of data should be encoded as a header or be represented in the body.
 The rule of thumb here is that implementations should be able to parse all headers orthogonally.
 Hence, the structure of one header SHOULD NOT depend on those of other headers.
-All data that cannot be represented in that way can be put into the `body`.
+All data that cannot be represented in that way SHOULD be put into the `body`.
 Implementations can then first parse the set of headers to determine the expected shape of the `body`, in order to continue parsing.
 
 #### Error

--- a/RFC-002-SWAP.md
+++ b/RFC-002-SWAP.md
@@ -123,15 +123,34 @@ The `negotiation_result` header is defined as follows:
 
 #### Body
 
-Together with the the value of the `protocol` header, the `negotiation_result` header determines the `body` of a SWAP RESPONSE.
+The content of the `body` depends on the values of the headers.
+The following diagram illustrates the process:
 
-In the case of a `successful` negotiation, the `body` of the response will contain the necessary information for the swap to start.
-This entirely depends on the chosen `protocol` and is thereby subject to the `protocol`'s RFC to define the `body`.
-In the case of a `failed` negotiation, the `body` of the response MAY contain an object of type `NegotiationError`.
+<!--
+@startuml
+
+title Parse SWAP RESPONSE body
+
+start
+
+:inspect `negotiation_result` header;
+
+if (negotiation_result) then (successful)
+  :inspect `protocol` header;
+  :parse body according to RFC of protocol;
+else (failed)
+  :parse body as `NegotiationError`;
+endif
+
+stop
+
+@enduml
+-->
+![](https://www.plantuml.com/plantuml/img/PP0nRiCm34LtdkAFzXMI9KNWZAaH3nrhLQ8I0QfeKFJGsqS9K1X8HeBlVppoKCsfhR-Po99bnkYqCgQlZn6NOHe_pzE07mb_H4-IQ9TANTWRvi9NiUGiIVbMhcks6JTsWNLFb2AwTw27tRYWgwltN6jSSq_0Lhcec7Z9Mr7RBa-bXmISzw8XbIjCS3aT8H7_cJrnRbmNNSeS-jTanNpUV0PLqRb5IaZnSPiiH8SsjLVS0G00)
+
 A `NegotiationError` is an object with a two properties:
-
-- `reason`: a string acting as the identifier for the `NegotiationError`.
-- `details`: an object containing more information about the error, depending on the given `reason`.
+  - `reason`: a string acting as the identifier for the `NegotiationError`.
+  - `details`: an object containing more information about the error, depending on the given `reason`.
 
 See the [Registry extensions](#registry-extensions)-section for examples of `NegotiationError`s.
 

--- a/RFC-002-SWAP.md
+++ b/RFC-002-SWAP.md
@@ -43,14 +43,14 @@
 
 ## Introduction
 
-This RFC introduces defines two things:
+This RFC serves two purposes:
 
-1. A terminology for describing the exchange of assets
-2. A REQUEST/RESPONSE pair of messages for `BAM!` to negotiate such an exchange between two parties
+1. Introduce terminology used to describe the exchange of assets.
+2. Define a REQUEST/RESPONSE message pair for two parties to negotiate such an exchange via `BAM!`.
 
 ## Terminology
 
-To describe the elements of an exchange, we are using the terms `Ledger`, `Asset` and `Alpha/Beta`.
+To describe the elements of an exchange, we use the terms `Ledger`, `Asset`, `Alpha` and `Beta`.
 
 ### Ledger
 
@@ -60,21 +60,21 @@ A ledger is anything that records ownership and allows transferal of that owners
 
 An asset is anything whose ownership can be transferred on a [ledger](#ledger).
 
-### Alpha/Beta
+### Alpha and Beta
 
-The terminology of **alpha** and **beta** is used to unambiguously refer to the assets and ledgers in an exchange.
-Such an exchange can thus be described as
-- transferring the ownership of the **alpha-asset** on the **alpha-ledger** from party A to party B
-- transferring the ownership of the **beta-asset** on the **beta-ledger** from party B to party A
+The terms **alpha** and **beta** are used to unambiguously identify assets and ledgers in an exchange.
+Such an exchange can thus be described as:
+- Transferring the ownership of the **alpha-asset** on the **alpha-ledger** from party A to party B.
+- Transferring the ownership of the **beta-asset** on the **beta-ledger** from party B to party A.
 
 This terminology has several advantages:
 
-1. it does not imply an order (compared to a terminology like **first**/**second**)
-2. it is not subjective to any of the parties (compared to a terminology like **source**/**target**, **incoming**/**outgoing** or **local**/**remote**)
+1. It does not imply an order (compared to a terminology like **first**/**second**).
+2. It is not subjective to any of the parties (compared to terminology like **source**/**target**, **incoming**/**outgoing** or **local**/**remote**).
 
 ## BAM! messages
 
-The messages to negotiate such an exchange consist of a `REQUEST` frame and an according `RESPONSE` frame.
+The messages to negotiate such an exchange consist of a `REQUEST` frame and a corresponding `RESPONSE` frame.
 
 ### SWAP REQUEST frame
 
@@ -90,8 +90,8 @@ To express all the information for an exchange, a SWAP REQUEST MUST include the 
 
 - `alpha_ledger`: describes the ledger the alpha-asset is tracked on
 - `beta_ledger`: describes the ledger the beta-asset is tracked on
-- `alpha_asset`: describes the asset who's ownership is transferred on the alpha-ledger
-- `beta_asset`: describes the asset who's ownership is transferred on the beta-ledger
+- `alpha_asset`: describes the asset whose ownership will be transferred on the `alpha_ledger`
+- `beta_asset`: describes the asset whose ownership will be transferred on the `beta_ledger`
 - `protocol`: describes the protocol that is used to transfer the ownership of the assets
 
 This RFC only defines these headers.
@@ -100,14 +100,14 @@ The actual definition of ledgers, assets and protocols is not subject to this RF
 #### Body
 
 The body of a SWAP REQUEST depends on the chosen `protocol`.
-It is therefore subject to RFCs which define such protocols to also define, which information is contained in the `body` of a SWAP REQUEST/RESPONSE frame.
+It is therefore subject to RFCs which define such protocols to also define which information is contained in the `body` of a SWAP REQUEST/RESPONSE frame.
 
 ### SWAP RESPONSE frame
 
 #### Definition
 
 A frame of type `REQUEST` implies a `RESPONSE`.
-We will refer to the response of a `SWAP REQUEST` as SWAP RESPONSE.
+We will refer to the response of a SWAP REQUEST as SWAP RESPONSE.
 
 The SWAP RESPONSE serves two purposes:
 
@@ -134,8 +134,8 @@ This entirely depends on the chosen `protocol` and is thereby subject to the `pr
 In the case of a `failed` negotiation, the `body` of the response MAY contain an object of type `NegotiationError`.
 A `NegotiationError` is an object with a two properties:
 
-- `reason`: A string, acting as the identifier for this `NegotiationError`.
-- `details`: An object containing more information about the error, depending on the given `reason`.
+- `reason`: a string acting as the identifier for the `NegotiationError`.
+- `details`: an object containing more information about the error, depending on the given `reason`.
 
 See the [Registry extensions](#registry-extensions)-section for examples of `NegotiationError`s.
 
@@ -215,12 +215,12 @@ This RFC extends the registry with the following elements:
 ### The type `Ledger`
 
 Subsequent RFCs can refer to this type if they want to define a particular ledger.
-A section "Ledgers" is added to the registry which tracks all currently defined ledgers.
+A section "Ledgers" is added to the registry which tracks all currently defined ledger types.
 
 ### The type `Asset`
 
 Subsequent RFCs can refer to this type if they want to define a particular asset.
-A section "Assets" is added to the registry which tracks all currently defined assets.
+A section "Assets" is added to the registry which tracks all currently defined asset types.
 
 ### The type `SwapProtocol`
 
@@ -266,7 +266,7 @@ TBD <!-- List known protocols in details -->
 #### `unknown-ledger`
 
 A ledger referenced by the sending party is unknown to the receiving party.
-Note that different networks of the same blockchain are different ledger!
+Note that different networks of the same blockchain are different ledgers!
 Bitcoin Testnet is a different ledger than Bitcoin Mainnet.
 
 ##### `details`

--- a/RFC-002-SWAP.md
+++ b/RFC-002-SWAP.md
@@ -148,31 +148,31 @@ Elements not relevant for this RFC or which are subject to later definition are 
 
 ```json
 {
-    "type": "REQUEST",
-    "id": 0,
-    "payload": {
-        "type": "SWAP",
-        "headers": {
-            "alpha_ledger": {
-                "value": "...",
-                "parameters": { ... }
-            },
-            "beta_ledger": {
-                "value": "...",
-                "parameters": { ... }
-            },
-            "alpha_asset": {
-                "value": "...",
-                "parameters": { ... }
-            },
-            "beta_asset": {
-                "value": "...",
-                "parameters": { ... }
-            },
-            "protocol": "...",
-        },
-        "body": { ... },
-    } 
+  "type": "REQUEST",
+  "id": 0,
+  "payload": {
+    "type": "SWAP",
+    "headers": {
+      "alpha_ledger": {
+        "value": "...",
+        "parameters": { ... }
+      },
+      "beta_ledger": {
+        "value": "...",
+        "parameters": { ... }
+      },
+      "alpha_asset": {
+        "value": "...",
+        "parameters": { ... }
+      },
+      "beta_asset": {
+        "value": "...",
+        "parameters": { ... }
+      },
+      "protocol": "...",
+    },
+    "body": { ... },
+  } 
 }
 ```
 
@@ -182,14 +182,14 @@ Elements not relevant for this RFC or which are subject to later definition are 
 
 ```json
 {
-    "type": "RESPONSE",
-    "id": 0,
-    "payload": {
-        "headers": {
-            "negotiation_result": "successful"
-        },
-        "body": { ... },
-    }
+  "type": "RESPONSE",
+  "id": 0,
+  "payload": {
+    "headers": {
+      "negotiation_result": "successful"
+    },
+    "body": { ... },
+  }
 }
 ```
 
@@ -197,14 +197,14 @@ Elements not relevant for this RFC or which are subject to later definition are 
 
 ```json
 {
-    "type": "RESPONSE",
-    "id": 0,
-    "payload": {
-        "headers": {
-            "negotiation_result": "failed"
-        },
-        "body": { ... },
-    }
+  "type": "RESPONSE",
+  "id": 0,
+  "payload": {
+    "headers": {
+      "negotiation_result": "failed"
+    },
+    "body": { ... },
+  }
 }
 ```
 
@@ -235,13 +235,13 @@ A section "Negotiation Errors" is added to the registry which tracks all current
 ### Headers
 
 | Header name          | Value                      |
-|----------------------|----------------------------|
+| -------------------- | -------------------------- |
 | `alpha_ledger`       | `Ledger`                   |
 | `betaledger`         | `Ledger`                   |
 | `alpha_asset`        | `Asset`                    |
 | `beta_asset`         | `Asset`                    |
 | `protocol`           | `SwapProtocol`             |
-| `negotiation_result` | `"successful" | "failed"`  |
+| `negotiation_result` | `"successful" OR "failed"` |
 
 ### The following `NegotiationError`s
 

--- a/RFC-002-SWAP.md
+++ b/RFC-002-SWAP.md
@@ -249,7 +249,7 @@ In the following section, each heading is a `reason`.
 
 #### `unsatisfactory-rate`
 
-If the receiving party doesn't not agree with the proposed rate, they can use the `unsatisfactory_rate` error to communicate this to the other party.
+The rate of `alpha_asset` to `beta_asset` is not satisfactory to the receiver.
 
 ##### `details`
 
@@ -257,7 +257,7 @@ TBD
 
 #### `protocol-unsupported`
 
-If the swap protocol specified in the `protocol` header is not known to the receiving party, they can use the `protocol-unsupported` error to communicate this to the other party.
+The protocol specified in the `protocol` header is not known to the receiving party.
 
 ##### `details`
 
@@ -265,7 +265,9 @@ TBD <!-- List known protocols in details -->
 
 #### `unknown-ledger`
 
-If any of the given ledgers (alpha or beta) are unknown to the receiving party, they can use the `unknown-ledger` error to communicate this.
+A ledger referenced by the sending party is unknown to the receiving party.
+Note that different networks of the same blockchain are different ledger!
+Bitcoin Testnet is a different ledger than Bitcoin Mainnet.
 
 ##### `details`
 
@@ -273,7 +275,7 @@ TBD <!-- List known ledgers in details -->
 
 #### `unknown-asset`
 
-If any of the given assets (alpha or beta) are unknown to the receiving party, they can use the `unknown-asset` error to communicate this.
+An asset referenced by the sending party is unknown to the receiving party.
 
 ##### `details`
 

--- a/RFC-002-SWAP.md
+++ b/RFC-002-SWAP.md
@@ -268,7 +268,7 @@ TBD <!-- List known assets in details -->
 
 ### Headers
 
-| Header name          | Value                      |
+| Header name          | Value type                 |
 | -------------------- | -------------------------- |
 | `alpha_ledger`       | `Ledger`                   |
 | `betaledger`         | `Ledger`                   |

--- a/RFC-002-SWAP.md
+++ b/RFC-002-SWAP.md
@@ -10,7 +10,7 @@
 - [Terminology](#terminology)
     - [Ledger](#ledger)
     - [Asset](#asset)
-    - [Alpha/Beta](#alphabeta)
+    - [Alpha and Beta](#alpha-and-beta)
 - [BAM! messages](#bam-messages)
     - [SWAP REQUEST frame](#swap-request-frame)
         - [Definition](#definition)
@@ -109,10 +109,7 @@ It is therefore subject to RFCs which define such protocols to also define which
 A frame of type `REQUEST` implies a `RESPONSE`.
 We will refer to the response of a SWAP REQUEST as SWAP RESPONSE.
 
-The SWAP RESPONSE serves two purposes:
-
-1. It contains the result of the negotiation initiated through the SWAP REQUEST
-2. It allows the receiving party to communicate information 
+A SWAP RESPONSE contains the result of the negotiation initiated through the SWAP REQUEST.
 
 #### Headers
 

--- a/RFC-002-SWAP.md
+++ b/RFC-002-SWAP.md
@@ -127,7 +127,7 @@ The `negotiation_result` header is defined as follows:
 Together with the the value of the `protocol` header, the `negotiation_result` header determines the `body` of a SWAP RESPONSE.
 
 In the case of a `successful` negotiation, the `body` of the response will contain the necessary information for the swap to start.
-This entirely depends on the chosen `protocol` and is thereby subject to the `protocol`s RFC to define the `body`.
+This entirely depends on the chosen `protocol` and is thereby subject to the `protocol`'s RFC to define the `body`.
 In the case of a `failed` negotiation, the `body` of the response MAY contain an object of type `NegotiationError`.
 A `NegotiationError` is an object with a two properties:
 

--- a/RFC-002-SWAP.md
+++ b/RFC-002-SWAP.md
@@ -223,7 +223,7 @@ Subsequent RFCs can refer to this type if they want to define a particular swap 
 
 ### The type `DeclineBody` and the initial set of possible values
 
-A section "DeclineBodys" is added to the registry which tracks all currently defined reasons.
+A section "DeclineBody" is added to the registry which tracks all currently defined reasons.
 Subsequent RFCs can refer to this type if they want to define new reasons for declining SWAP REQUESTs.
 
 The following `DeclineBody`s are added to the list.

--- a/RFC-002-SWAP.md
+++ b/RFC-002-SWAP.md
@@ -86,11 +86,13 @@ For the SWAP REQUEST message, this type is `SWAP`.
 
 To express all the information for an exchange, a SWAP REQUEST MUST include the following headers:
 
-- `alpha_ledger`: describes the ledger the alpha-asset is tracked on
-- `beta_ledger`: describes the ledger the beta-asset is tracked on
-- `alpha_asset`: describes the asset whose ownership will be transferred on the `alpha_ledger`
-- `beta_asset`: describes the asset whose ownership will be transferred on the `beta_ledger`
-- `protocol`: describes the protocol that is used to transfer the ownership of the assets
+| Header         | Value (Link to registry section)                                                         | Description                                                          |
+| -------------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `alpha_ledger` | [Ledger](https://github.com/comit-network/RFCs/blob/master/registry.md#ledgers)          | The ledger the alpha-asset is tracked on.                            |
+| `beta_ledger`  | [Ledger](https://github.com/comit-network/RFCs/blob/master/registry.md#ledgers)          | The ledger the beta-asset is tracked on.                             |
+| `alpha_asset`  | [Asset](https://github.com/comit-network/RFCs/blob/master/registry.md#assets)            | The asset whose ownership will be transferred on the `alpha_ledger`. |
+| `beta_asset`   | [Asset](https://github.com/comit-network/RFCs/blob/master/registry.md#assets)            | The asset whose ownership will be transferred on the `beta_ledger`.  |
+| `protocol`     | [SWAP Protocol](https://github.com/comit-network/RFCs/blob/master/registry.md#protocols) | The protocol that is used to transfer the ownership of the assets.   |
 
 This RFC only defines these headers.
 The actual definition of ledgers, assets and protocols is not subject to this RFC.

--- a/RFC-002-SWAP.md
+++ b/RFC-002-SWAP.md
@@ -29,9 +29,7 @@
     - [The type `Ledger`](#the-type-ledger)
     - [The type `Asset`](#the-type-asset)
     - [The type `SwapProtocol`](#the-type-swapprotocol)
-    - [The type `NegotiationError`](#the-type-negotiationerror)
-    - [Headers](#headers-2)
-    - [The following `NegotiationError`s](#the-following-negotiationerrors)
+    - [The type `NegotiationError` and the initial set of possible errors](#the-type-negotiationerror-and-the-initial-set-of-possible-errors)
         - [`unsatisfactory-rate`](#unsatisfactory-rate)
             - [`details`](#details)
         - [`protocol-unsupported`](#protocol-unsupported)
@@ -40,6 +38,7 @@
             - [`details`](#details-2)
         - [`unknown-asset`](#unknown-asset)
             - [`details`](#details-3)
+    - [Headers](#headers-2)
 
 ## Introduction
 
@@ -211,38 +210,26 @@ This RFC extends the registry with the following elements:
 
 ### The type `Ledger`
 
-Subsequent RFCs can refer to this type if they want to define a particular ledger.
 A section "Ledgers" is added to the registry which tracks all currently defined ledger types.
+Subsequent RFCs can refer to this type if they want to define a particular ledger.
 
 ### The type `Asset`
 
-Subsequent RFCs can refer to this type if they want to define a particular asset.
 A section "Assets" is added to the registry which tracks all currently defined asset types.
+Subsequent RFCs can refer to this type if they want to define a particular asset.
 
 ### The type `SwapProtocol`
 
-Subsequent RFCs can refer to this type if they want to define a particular swap protocol.
 A section "Protocols" is added to the registry which tracks all currently defined protocols.
+Subsequent RFCs can refer to this type if they want to define a particular swap protocol.
 
-### The type `NegotiationError`
+### The type `NegotiationError` and the initial set of possible errors
 
-Subsequent RFCs can refer to this type if they want to define a particular negotiation error.
 A section "Negotiation Errors" is added to the registry which tracks all currently defined errors.
+Subsequent RFCs can refer to this type if they want to define a particular negotiation error.
 
-### Headers
-
-| Header name          | Value                      |
-| -------------------- | -------------------------- |
-| `alpha_ledger`       | `Ledger`                   |
-| `betaledger`         | `Ledger`                   |
-| `alpha_asset`        | `Asset`                    |
-| `beta_asset`         | `Asset`                    |
-| `protocol`           | `SwapProtocol`             |
-| `negotiation_result` | `"successful" OR "failed"` |
-
-### The following `NegotiationError`s
-
-In the following section, each heading is a `reason`.
+The following `NegotiationError`s are added to the list.
+Each heading represents the `reason` of the `NegotiationError`
 
 #### `unsatisfactory-rate`
 
@@ -277,3 +264,15 @@ An asset referenced by the sending party is unknown to the receiving party.
 ##### `details`
 
 TBD <!-- List known assets in details -->
+
+
+### Headers
+
+| Header name          | Value                      |
+| -------------------- | -------------------------- |
+| `alpha_ledger`       | `Ledger`                   |
+| `betaledger`         | `Ledger`                   |
+| `alpha_asset`        | `Asset`                    |
+| `beta_asset`         | `Asset`                    |
+| `protocol`           | `SwapProtocol`             |
+| `negotiation_result` | `"successful" OR "failed"` |

--- a/RFC-003-SWAP-Basic.md
+++ b/RFC-003-SWAP-Basic.md
@@ -212,9 +212,9 @@ This indicates to the sender that the difference between `alpha_expiry` and `bet
 
 #### `details`
 
-| detail | type   | description                                                                         |
-| :------------ | :----- | :---------------------------------------------------------------------------------- |
-| min_time      | number | The minimum time difference between the HLTCs in seconds that the receiver requires |
+| detail   | type   | required | description                                                                         |
+| :------- | :----- | :------- | :---------------------------------------------------------------------------------- |
+| min_time | number | no       | The minimum time difference between the HLTCs in seconds that the receiver requires |
 
 ### Section for hash functions
 
@@ -301,7 +301,9 @@ Elements not relevant for this RFC or which are subject to later definition are 
     },
     "body": { 
       "reason": "timeouts-too-tight",
-      "details": {}
+      "details": {
+          "min_time": 7200
+      }
     },
   }
 }

--- a/RFC-003-SWAP-Basic.md
+++ b/RFC-003-SWAP-Basic.md
@@ -117,7 +117,7 @@ If `alpha_expiry` or `beta_expiry` are in the past, implementations SHOULD consi
 
 ### SWAP Response
 
-If responding with "successful" for the `negotiation_result` header, the responder MUST include the following fields in the response body:
+If responding with `successful` for the `negotiation_result` header, the responder MUST include the following fields in the response body:
 
 | Name                    | JSON Encoding | Description                                                                                              |
 | ----------------------- | ------------- | -------------------------------------------------------------------------------------------------------- |
@@ -212,20 +212,22 @@ This indicates to the sender that the difference between `alpha_expiry` and `bet
 
 #### `details`
 
-| property name | type   | description                                                                         |
+| detail | type   | description                                                                         |
 | :------------ | :----- | :---------------------------------------------------------------------------------- |
 | min_time      | number | The minimum time difference between the HLTCs in seconds that the receiver requires |
 
 ### Section for hash functions
 
 A new section for listing hash functions is added.
-The section is bootstrapped with the `SHA-256` hash function.
+`SHA-256` is added as an initial value.
 
 ## References
 1. https://en.bitcoin.it/wiki/Atomic_swap
 2. https://tools.ietf.org/html/rfc4634#section-4.1
 
 ## Examples
+
+Elements not relevant for this RFC or which are subject to later definition are filled in with "...".
 
 ### SWAP REQUEST frame
 ``` json

--- a/RFC-003-SWAP-Basic.md
+++ b/RFC-003-SWAP-Basic.md
@@ -7,6 +7,7 @@
 
 **Table of Contents**
 - [Description](#description)
+
 - [Concepts](#concepts)
     - [Identity](#identity)
     - [Hash Time Lock Contract (HTLC)](#hash-time-lock-contract-htlc)
@@ -18,8 +19,8 @@
     - [Swap Response (Decline)](#swap-response-decline)
         - [`timeouts-too-tight`](#timeouts-too-tight)
 - [Execution Phase](#execution-phase)
-    - [1. Alice deploys α-HTLC](#1-alice-deploys-α-htlc)
-    - [2. Bob deploys β-HTLC](#2-bob-deploys-β-htlc)
+    - [1. Alice deploys α-HTLC](#1-alice-deploys-%CE%B1-htlc)
+    - [2. Bob deploys β-HTLC](#2-bob-deploys-%CE%B2-htlc)
     - [3. Alice redeems](#3-alice-redeems)
     - [4. Bob redeems](#4-bob-redeems)
 - [Application Considerations](#application-considerations)

--- a/RFC-003-SWAP-Basic.md
+++ b/RFC-003-SWAP-Basic.md
@@ -24,14 +24,14 @@
 - [Security Considerations](#security-considerations)
 - [Registry Extensions](#registry-extensions)
     - [Ledgers have identities](#ledgers-have-identities)
-    - [Negotiation error for tight timeouts](#negotiation-error-for-tight-timeouts)
+    - [Decline reason for tight timeouts](#decline-reason-for-tight-timeouts)
         - [`details`](#details)
     - [Section for hash functions](#section-for-hash-functions)
 - [References](#references)
 - [Examples](#examples)
     - [SWAP REQUEST frame](#swap-request-frame)
-    - [SWAP RESPONSE (successful negotiation)](#swap-response-successful-negotiation)
-    - [SWAP RESPONSE (failed negotiation due to tight timeouts)](#swap-response-failed-negotiation-due-to-tight-timeouts)
+    - [Response to Accepted SWAP REQUEST](#response-to-accepted-swap-request)
+    - [Response to declined SWAP RESPONSE (declined because too tight timeouts)](#response-to-declined-swap-response-declined-because-too-tight-timeouts)
 
 ## Description
 
@@ -205,10 +205,10 @@ This RFC extends the [registry](./registry.md) in the following ways:
 
 The ledger section now includes an `identity` table which specifies the exact identity to use on a particular ledger.
 
-### Negotiation error for tight timeouts
+### Decline reason for tight timeouts
 
-A `NegotiationError` with the reason `timeouts-too-tight` is added.
-This indicates to the sender that the difference between `alpha_expiry` and `beta_expiry` is too small and the receiver may accept the swap if they are given more time.
+The decline reason `timeouts-too-tight` is added.
+This indicates to the sender that the difference between `alpha_expiry` and `beta_expiry` is too small and the receiver MAY accept the swap if they are given more time.
 
 #### `details`
 
@@ -271,7 +271,7 @@ Elements not relevant for this RFC or which are subject to later definition are 
 }
 ```
 
-### SWAP RESPONSE (successful negotiation)
+### Response to Accepted SWAP REQUEST
 
 ``` json
 {
@@ -279,7 +279,7 @@ Elements not relevant for this RFC or which are subject to later definition are 
   "id": 0,
   "payload": {
     "headers": {
-      "negotiation_result": "successful"
+      "decision": "accepted"
     },
     "body": { 
       "alpha_redeem_identity": "...",
@@ -289,7 +289,7 @@ Elements not relevant for this RFC or which are subject to later definition are 
 }
 ```
 
-### SWAP RESPONSE (failed negotiation due to tight timeouts)
+### Response to declined SWAP RESPONSE (declined because too tight timeouts)
 
 ``` json
 {
@@ -297,7 +297,7 @@ Elements not relevant for this RFC or which are subject to later definition are 
   "id": 0,
   "payload": {
     "headers": {
-      "negotiation_result": "failed"
+      "decision": "declined"
     },
     "body": { 
       "reason": "timeouts-too-tight",

--- a/RFC-003-SWAP-Basic.md
+++ b/RFC-003-SWAP-Basic.md
@@ -7,7 +7,6 @@
 
 **Table of Contents**
 - [Description](#description)
-
 - [Concepts](#concepts)
     - [Identity](#identity)
     - [Hash Time Lock Contract (HTLC)](#hash-time-lock-contract-htlc)
@@ -15,22 +14,24 @@
     - [SWAP Request Header](#swap-request-header)
         - [`hash_function`](#hash_function)
     - [SWAP Request Body](#swap-request-body)
-    - [Swap Response (Accept)](#swap-response-accept)
-    - [Swap Response (Decline)](#swap-response-decline)
-        - [`timeouts-too-tight`](#timeouts-too-tight)
+    - [SWAP Response](#swap-response)
 - [Execution Phase](#execution-phase)
-    - [1. Alice deploys α-HTLC](#1-alice-deploys-%CE%B1-htlc)
-    - [2. Bob deploys β-HTLC](#2-bob-deploys-%CE%B2-htlc)
+    - [1. Alice deploys α-HTLC](#1-alice-deploys-α-htlc)
+    - [2. Bob deploys β-HTLC](#2-bob-deploys-β-htlc)
     - [3. Alice redeems](#3-alice-redeems)
     - [4. Bob redeems](#4-bob-redeems)
 - [Application Considerations](#application-considerations)
 - [Security Considerations](#security-considerations)
 - [Registry Extensions](#registry-extensions)
+    - [Ledgers have identities](#ledgers-have-identities)
+    - [Negotiation error for tight timeouts](#negotiation-error-for-tight-timeouts)
+        - [`details`](#details)
+    - [Section for hash functions](#section-for-hash-functions)
 - [References](#references)
-- [Bitcoin to Ethereum](#bitcoin-to-ethereum)
-    - [SWAP REQUEST](#swap-request)
-    - [SWAP RESPONSE (accept)](#swap-response-accept)
-    - [SWAP RESPONSE (reject: `timeouts-too-tight`)](#swap-response-reject-timeouts-too-tight)
+- [Examples](#examples)
+    - [SWAP REQUEST frame](#swap-request-frame)
+    - [SWAP RESPONSE (successful negotiation)](#swap-response-successful-negotiation)
+    - [SWAP RESPONSE (failed negotiation due to tight timeouts)](#swap-response-failed-negotiation-due-to-tight-timeouts)
 
 ## Description
 
@@ -104,39 +105,24 @@ How to construct HTLCs based on SHA-256 and other hash functions for particular 
 ### SWAP Request Body
 When `comit-rfc-003` is used as the value for `protocol` for a SWAP REQUEST message the body MUST have the following fields:
 
-| Name                    | JSON Encoding       | Description                                                                                               |
-|:-------------------------|:---------------------|:-----------------------------------------------------------------------------------------------------------|
-| `alpha_expiry`          | `u32`               | The UNIX timestamp of the time-lock on the alpha HTLC                                                     |
-| `beta_expiry`           | `u32`               | The UNIX timestamp of the time-lock on the beta HTLC                                                      |
-| `alpha_refund_identity` | `α::Identity`       | The identity on α that **A** can be transferred to after `alpha_expiry`                                   |
-| `beta_redeem_identity`  | `β::Identity`       | The identity on β that **B** will be transferred to when the β-HTLC is activated with the correct secret  |
-| `secret_hash`           | `hex-encoded-bytes` | The output of calling `hash_function` on the secret                                                       |
+| Name                    | JSON Encoding       | Description                                                                                              |
+| :---------------------- | :------------------ | :------------------------------------------------------------------------------------------------------- |
+| `alpha_expiry`          | `u32`               | The UNIX timestamp of the time-lock on the alpha HTLC                                                    |
+| `beta_expiry`           | `u32`               | The UNIX timestamp of the time-lock on the beta HTLC                                                     |
+| `alpha_refund_identity` | `α::Identity`       | The identity on α that **A** can be transferred to after `alpha_expiry`                                  |
+| `beta_redeem_identity`  | `β::Identity`       | The identity on β that **B** will be transferred to when the β-HTLC is activated with the correct secret |
+| `secret_hash`           | `hex-encoded-bytes` | The output of calling `hash_function` on the secret                                                      |
 
 If `alpha_expiry` or `beta_expiry` are in the past, implementations SHOULD consider the request to be invalid.
 
-### Swap Response (Accept)
+### SWAP Response
 
-If responding with `OK00`, the responder MUST include the following fields in the response body:
+If responding with "successful" for the `negotiation_result` header, the responder MUST include the following fields in the response body:
 
-| Name                    | JSON Encoding | Description                                                                                               |
-|-------------------------|---------------|-----------------------------------------------------------------------------------------------------------|
-| `alpha_redeem_identity` | `α::Identity` | The identity on α that **A** will be transferred to when the α-HTLC is activated with the correct secret  |
-| `beta_refund_identity`  | `β::Identity` | The identity on β that **B** will be transferred to when the β-HTLC is activated after `beta_expiry`      |
-
-
-### Swap Response (Decline)
-
-This RFC extends the SWAP [reason header](./RFC-002-SWAP.md#reason) with the following possible values when responding with a `RE20 - Declined` status.
-
-#### `timeouts-too-tight`
-
-This indicates to the sender that the difference between `alpha_expiry` and `beta_expiry` is too small and the receiver may accept the swap if they are given more time.
-
-Parameters:
-
-| Name          | JSON Encoding | Description                                                                         |
-| ------------- | ------------- | ----------------------------------------------------------------------------------- |
-| min-time      | `u32`         | The minimum time difference between the HLTCs in seconds that the receiver requires |
+| Name                    | JSON Encoding | Description                                                                                              |
+| ----------------------- | ------------- | -------------------------------------------------------------------------------------------------------- |
+| `alpha_redeem_identity` | `α::Identity` | The identity on α that **A** will be transferred to when the α-HTLC is activated with the correct secret |
+| `beta_refund_identity`  | `β::Identity` | The identity on β that **B** will be transferred to when the β-HTLC is activated after `beta_expiry`     |
 
 ## Execution Phase
 
@@ -215,88 +201,106 @@ A security model of the protocol and its associated parameters will be included 
 
 This RFC extends the [registry](./registry.md) in the following ways:
 
-- **identity**: The ledger section now includes an `identity` table which specifies the exact identity to use on a particular ledger.
-- **`reason` header**: Adds an additional possible value `timeouts-too-tight` to the `reason` header.
-- **Hash Functions**: Adds a new section for listing hash functions and how to refer to them and adds `SHA-256` to this section.
+### Ledgers have identities
+
+The ledger section now includes an `identity` table which specifies the exact identity to use on a particular ledger.
+
+### Negotiation error for tight timeouts
+
+A `NegotiationError` with the reason `timeouts-too-tight` is added.
+This indicates to the sender that the difference between `alpha_expiry` and `beta_expiry` is too small and the receiver may accept the swap if they are given more time.
+
+#### `details`
+
+|property name|type|description|
+|:---|:---|:---|
+|min_time|number|The minimum time difference between the HLTCs in seconds that the receiver requires|
+
+### Section for hash functions
+
+A new section for listing hash functions is added.
+The section is bootstrapped with the `SHA-256` hash function.
 
 ## References
 1. https://en.bitcoin.it/wiki/Atomic_swap
 2. https://tools.ietf.org/html/rfc4634#section-4.1
 
-# Examples
+## Examples
 
-## Bitcoin to Ethereum
-
-### SWAP REQUEST
+### SWAP REQUEST frame
 ``` json
 {
-  "type": "SWAP",
-  "headers": {
-    "alpha_ledger": {
-      "value": "bitcoin",
-      "parameters": {
-        "network": "regtest"
-      }
-    },
-    "beta_ledger": {
-      "value": "ethereum",
-      "parameters": {
-        "network": "ropsten"
-      }
-    },
-    "alpha_asset": {
-      "value": "bitcoin",
-      "parameters": {
-        "quantity": "100000000"
-      }
-    },
-    "beta_asset": {
-      "value": "ether",
-      "parameters": {
-        "quantity": "21000000000000000000"
-      }
-    },
-    "protocol": {
-      "value": "comit-rfc-003",
-      "parameters": {
-          "hash_function": "SHA-256"
-      }
-    }
-  },
-  "body": {
-    "alpha_expiry": 1547697466,
-    "beta_expiry": 1547611066,
-    "alpha_refund_identity": "482d8bc0a2f6bb72f38a62bcafb85c2c04b8e9d4",
-    "beta_redeem_identity": "0xdaa74f7c9d4894f396860037ca727a2ba726819d",
-    "secret_hash": "07954accecf3a81b484b0bbb9cc63034fb6c1037f234288f5d297aa9f669a756"
-  }
-}
-```
-
-### SWAP RESPONSE (accept)
-
-``` json
-{
-  "status": "OK00",
-  "body": {
-    "alpha_redeem_identity": "3c045591864c6b52658db072e47a01f658d53e0f",
-    "beta_redeem_identity": "0xb39161874921fd329233a9134e537425bb4e72fb"
-  }
-}
-```
-
-### SWAP RESPONSE (reject: `timeouts-too-tight`)
-
-``` json
-{
-    "status": "RE20",
-    "headers" : {
-        "reason" : {
-            "value" : "timeouts-too-tight",
-            "parameters" : {
-                "min-time" : 172800,
+    "type": "REQUEST",
+    "id": 0,
+    "payload": {
+        "type": "SWAP",
+        "headers": {
+            "alpha_ledger": {
+                "value": "...",
+                "parameters": { ... }
+            },
+            "beta_ledger": {
+                "value": "...",
+                "parameters": { ... }
+            },
+            "alpha_asset": {
+                "value": "...",
+                "parameters": { ... }
+            },
+            "beta_asset": {
+                "value": "...",
+                "parameters": { ... }
+            },
+            "protocol": {
+                "value": "comit-rfc-003",
+                "parameters": {
+                    "hash_function": "SHA-256"
+                }
             }
+        },
+        "body": {
+            "alpha_expiry": ...,
+            "beta_expiry": ...,
+            "alpha_refund_identity": "...",
+            "beta_redeem_identity": "...",
+            "secret_hash": "..."
         }
+    } 
+}
+```
+
+### SWAP RESPONSE (successful negotiation)
+
+``` json
+{
+    "type": "RESPONSE",
+    "id": 0,
+    "payload": {
+        "headers": {
+            "negotiation_result": "successful"
+        },
+        "body": { 
+            "alpha_redeem_identity": "...",
+            "beta_redeem_identity": "..."
+        },
+    }
+}
+```
+
+### SWAP RESPONSE (failed negotiation due to tight timeouts)
+
+``` json
+{
+    "type": "RESPONSE",
+    "id": 0,
+    "payload": {
+        "headers": {
+            "negotiation_result": "failed"
+        },
+        "body": { 
+            "reason": "timeouts-too-tight",
+            "details": {}
+        },
     }
 }
 ```

--- a/RFC-003-SWAP-Basic.md
+++ b/RFC-003-SWAP-Basic.md
@@ -212,9 +212,9 @@ This indicates to the sender that the difference between `alpha_expiry` and `bet
 
 #### `details`
 
-|property name|type|description|
-|:---|:---|:---|
-|min_time|number|The minimum time difference between the HLTCs in seconds that the receiver requires|
+| property name | type   | description                                                                         |
+| :------------ | :----- | :---------------------------------------------------------------------------------- |
+| min_time      | number | The minimum time difference between the HLTCs in seconds that the receiver requires |
 
 ### Section for hash functions
 
@@ -230,42 +230,42 @@ The section is bootstrapped with the `SHA-256` hash function.
 ### SWAP REQUEST frame
 ``` json
 {
-    "type": "REQUEST",
-    "id": 0,
-    "payload": {
-        "type": "SWAP",
-        "headers": {
-            "alpha_ledger": {
-                "value": "...",
-                "parameters": { ... }
-            },
-            "beta_ledger": {
-                "value": "...",
-                "parameters": { ... }
-            },
-            "alpha_asset": {
-                "value": "...",
-                "parameters": { ... }
-            },
-            "beta_asset": {
-                "value": "...",
-                "parameters": { ... }
-            },
-            "protocol": {
-                "value": "comit-rfc-003",
-                "parameters": {
-                    "hash_function": "SHA-256"
-                }
-            }
-        },
-        "body": {
-            "alpha_expiry": ...,
-            "beta_expiry": ...,
-            "alpha_refund_identity": "...",
-            "beta_redeem_identity": "...",
-            "secret_hash": "..."
+  "type": "REQUEST",
+  "id": 0,
+  "payload": {
+    "type": "SWAP",
+    "headers": {
+      "alpha_ledger": {
+        "value": "...",
+        "parameters": { ... }
+      },
+      "beta_ledger": {
+        "value": "...",
+        "parameters": { ... }
+      },
+      "alpha_asset": {
+        "value": "...",
+        "parameters": { ... }
+      },
+      "beta_asset": {
+        "value": "...",
+        "parameters": { ... }
+      },
+      "protocol": {
+        "value": "comit-rfc-003",
+        "parameters": {
+          "hash_function": "SHA-256"
         }
-    } 
+      }
+    },
+    "body": {
+      "alpha_expiry": ...,
+      "beta_expiry": ...,
+      "alpha_refund_identity": "...",
+      "beta_redeem_identity": "...",
+      "secret_hash": "..."
+    }
+  } 
 }
 ```
 
@@ -273,17 +273,17 @@ The section is bootstrapped with the `SHA-256` hash function.
 
 ``` json
 {
-    "type": "RESPONSE",
-    "id": 0,
-    "payload": {
-        "headers": {
-            "negotiation_result": "successful"
-        },
-        "body": { 
-            "alpha_redeem_identity": "...",
-            "beta_redeem_identity": "..."
-        },
-    }
+  "type": "RESPONSE",
+  "id": 0,
+  "payload": {
+    "headers": {
+      "negotiation_result": "successful"
+    },
+    "body": { 
+      "alpha_redeem_identity": "...",
+      "beta_redeem_identity": "..."
+    },
+  }
 }
 ```
 
@@ -291,16 +291,16 @@ The section is bootstrapped with the `SHA-256` hash function.
 
 ``` json
 {
-    "type": "RESPONSE",
-    "id": 0,
-    "payload": {
-        "headers": {
-            "negotiation_result": "failed"
-        },
-        "body": { 
-            "reason": "timeouts-too-tight",
-            "details": {}
-        },
-    }
+  "type": "RESPONSE",
+  "id": 0,
+  "payload": {
+    "headers": {
+      "negotiation_result": "failed"
+    },
+    "body": { 
+      "reason": "timeouts-too-tight",
+      "details": {}
+    },
+  }
 }
 ```

--- a/assets/RFC002-parse-response-body.puml
+++ b/assets/RFC002-parse-response-body.puml
@@ -1,0 +1,18 @@
+@startuml
+
+title Parse SWAP RESPONSE body
+
+start
+
+:inspect `decision` header;
+
+if (decision) then (accepted)
+  :inspect `protocol` header;
+  :parse body according to RFC of protocol;
+else (declined)
+  :parse body as `DeclineBody`;
+endif
+
+stop
+
+@enduml

--- a/registry.md
+++ b/registry.md
@@ -1,24 +1,21 @@
-# Table of contents
-
-<!-- markdown-toc start -->
-- [Registry](#registry)
-    - [Description](#description)
-    - [Ledgers](#ledgers)
-        - [`bitcoin` Parameters](#bitcoin-parameters)
-            - [Bitcoin Networks](#bitcoin-networks)
-        - [`ethereum` Parameters](#ethereum-parameters)
-            - [Ethereum Networks](#ethereum-networks)
-    - [Assets](#assets)
-        - [`bitcoin` Parameters](#bitcoin-parameters-1)
-        - [`ether` Parameters](#ether-parameters)
-        - [`erc20` Parameters](#erc20-parameters)
-    - [Identities](#identities)
-    - [Protocols](#protocols)
-    - [Hash Functions](#hash-functions)
-    - [Headers](#headers)
-<!-- markdown-toc end -->
-
 # Registry
+
+**Table of contents**
+- [Description](#description)
+- [Ledgers](#ledgers)
+    - [`bitcoin` Parameters](#bitcoin-parameters)
+        - [Bitcoin Networks](#bitcoin-networks)
+    - [`ethereum` Parameters](#ethereum-parameters)
+        - [Ethereum Networks](#ethereum-networks)
+- [Assets](#assets)
+    - [`bitcoin` Parameters](#bitcoin-parameters-1)
+    - [`ether` Parameters](#ether-parameters)
+    - [`erc20` Parameters](#erc20-parameters)
+- [Protocols](#protocols)
+- [Negotiation Errors](#negotiation-errors)
+- [Identities](#identities)
+- [Hash Functions](#hash-functions)
+- [Headers](#headers)
 
 ## Description
 
@@ -100,6 +97,19 @@ And the possible parameters they each may have:
 | `quantity` | `u256`                | The ERC20 contract value to be transferred (not the decimal token quantity) |
 | `address`  | `0x` prefixed address | The address of the ERC20 contract                                           |
 
+## Protocols
+
+<!-- TODO: Use same table format here -->
+
+The following is a list of protocols defined in COMIT RFCs for use in the `protocol` header of a SWAP message.
+
+| Name                   | Reference                       |
+|:----------------------- |:-------------------------------- |
+| Basic HTLC Atomic Swap | [RFC-003](./RFC-003-SWAP-Basic) |
+
+## Negotiation Errors
+
+<!-- TODO: Add negotiation errors here -->
 
 ## Identities
 
@@ -109,15 +119,6 @@ And the possible parameters they each may have:
 |:---------|:--------------|:-------------------------|:--------------------------------------------|---------------------------------------------------------------------------------------|
 | Bitcoin  | `pubkeyhash`  | `hex-encoded-bytes (20)` | [RFC-004](./RFC-005-SWAP-Basic-Bitcoin.md)  | The result of applying SHA256 and then RIPEMD160 to a SECP256k1 compressed public key |
 | Ethereum | `address`     | `0x` prefixed address    | [RFC-007](./RFC-007-SWAP-Basic-Ether.md) | An Ethereum Address                                                                   |
-
-## Protocols
-
-The following is a list of protocols defined in COMIT RFCs for use in the `protocol` header of a SWAP message.
-
-| Name                   | Reference                       |
-|:----------------------- |:-------------------------------- |
-| Basic HTLC Atomic Swap | [RFC-003](./RFC-003-SWAP-Basic) |
-
 
 ## Hash Functions
 
@@ -130,12 +131,11 @@ The following is a list of cryptographic hash functions for use within COMIT pro
 
 ## Headers
 
-| Name           | Reference                                    | `value`                                                                                                                                                                                                                                                                                                                                                                          |
-|:---------------|:---------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `alpha_ledger` | [RFC-002](./RFC-002-SWAP.md#alpha_ledger)    | See [Ledgers](#ledgers)                                                                                                                                                                                                                                                                                                                                                          |
-| `beta_ledger`  | [RFC-002](./RFC-002-SWAP.md#beta_ledger)     | See [Ledgers](#ledgers)                                                                                                                                                                                                                                                                                                                                                          |
-| `alpha_asset ` | [RFC-002](./RFC-002-SWAP.md#alpha_asset)     | See [Assets](#assets)                                                                                                                                                                                                                                                                                                                                                            |
-| `beta_asset`   | [RFC-002](./RFC-002-SWAP.md#beta_asset)      | See [Assets](#assets)                                                                                                                                                                                                                                                                                                                                                            |
-| `protocol`     | [RFC-002](./RFC-002-SWAP.md#protocol)        | See [Protocols](#protocols)                                                                                                                                                                                                                                                                                                                                                      |
-| `reason`       | [RFC-002](./RFC-002-SWAP.md#reason-optional) | [`unsatisfactory-rate`](./RFC-002-SWAP.md#reason-optional), [`unsatisfactory-quantity`](./RFC-002-SWAP.md#reason-optional), [`protocol-unsupported`](./RFC-002-SWAP.md#reason-optional), [`unsupported-ledger`](./RFC-002-SWAP.md#reason-optional), [`unavailable-asset`](./RFC-002-SWAP.md#reason-optional), [`timeouts-too-tight`](./RFC-003-SWAP-Basic.md#timeouts-too-tight) |
-|                |                                              |                                                                                                                                                                                                                                                                                                                                                                                  |
+ | Name | Reference | `value` |
+ |:---|:--- |:--- |
+ | `alpha_ledger` | [RFC-002](./RFC-002-SWAP.md) | See [Ledgers](#ledgers) |
+ | `beta_ledger` | [RFC-002](./RFC-002-SWAP.md) | See [Ledgers](#ledgers) |
+ | `alpha_asset` | [RFC-002](./RFC-002-SWAP.md) | See [Assets](#assets) |
+ | `beta_asset` | [RFC-002](./RFC-002-SWAP.md) | See [Assets](#assets) |
+ | `protocol` | [RFC-002](./RFC-002-SWAP.md) | See [Protocols](#protocols) |
+ | `negotiation_result` | [RFC-002](./RFC-002-SWAP.md) | `"successful" | "failed"` |

--- a/registry.md
+++ b/registry.md
@@ -46,7 +46,7 @@ A SWAP request and the accroding response allow for the following headers to app
 - `alpha_asset`
 - `beta_asset`
 - `protocol`
-- `negotiation_result`
+- `decision`
 
 Please refer to [RFC-002](./RFC-002-SWAP.md) for the exact definition of those headers.
 

--- a/registry.md
+++ b/registry.md
@@ -2,6 +2,9 @@
 
 **Table of contents**
 - [Description](#description)
+- [Request types](#request-types)
+    - [SWAP](#swap)
+- [ERROR frame types](#error-frame-types)
 - [Ledgers](#ledgers)
     - [`bitcoin` Parameters](#bitcoin-parameters)
         - [Bitcoin Networks](#bitcoin-networks)
@@ -15,12 +18,40 @@
 - [SWAP decline reasons](#swap-decline-reasons)
 - [Identities](#identities)
 - [Hash Functions](#hash-functions)
-- [Request types](#request-types)
-    - [SWAP](#swap)
 
 ## Description
 
-This registry defines all types used across COMIT RFCs. This registry may be expanded with new RFCs.
+This registry defines all types used across COMIT RFCs.
+This registry may be expanded with new RFCs.
+
+## Request types
+
+### SWAP
+
+Introduced in [RFC-002](./RFC-002-SWAP.md).
+
+A SWAP request and the accroding response allow for the following headers to appear:
+
+- `alpha_ledger`
+- `beta_ledger`
+- `alpha_asset`
+- `beta_asset`
+- `protocol`
+- `negotiation_result`
+
+Please refer to [RFC-002](./RFC-002-SWAP.md) for the exact definition of those headers.
+
+## ERROR frame types
+
+Implementations SHOULD be aware of the following list of ERROR frame types.
+This list can be extended by RFCs, so implementations SHOULD be prepared to receive an ERROR frame that is not listed here.
+
+| Type                       | Reference                   |
+| -------------------------- | --------------------------- |
+| `unknown-frame-type`       | [RFC-001](./RFC-001-BAM.md) |
+| `malformed-frame`          | [RFC-001](./RFC-001-BAM.md) |
+| `unknown-request-type`     | [RFC-001](./RFC-001-BAM.md) |
+| `unknown-mandatory-header` | [RFC-001](./RFC-001-BAM.md) |
 
 ## Ledgers
 
@@ -129,20 +160,3 @@ The following is a list of cryptographic hash functions for use within COMIT pro
 | Name      | Reference                                                      |
 | :-------- | :------------------------------------------------------------- |
 | `SHA-256` | [IETF RFC463](https://tools.ietf.org/html/rfc4634#section-4.1) |
-
-## Request types
-
-### SWAP
-
-Introduced in [RFC-002](./RFC-002-SWAP.md).
-
-A SWAP request and the accroding response allow for the following headers to appear:
-
-- `alpha_ledger`
-- `beta_ledger`
-- `alpha_asset`
-- `beta_asset`
-- `protocol`
-- `negotiation_result`
-
-Please refer to [RFC-002](./RFC-002-SWAP.md) for the exact definition of those headers.

--- a/registry.md
+++ b/registry.md
@@ -3,20 +3,20 @@
 **Table of contents**
 - [Description](#description)
 - [Ledgers](#ledgers)
-  - [`bitcoin` Parameters](#bitcoin-parameters)
-    - [Bitcoin Networks](#bitcoin-networks)
-  - [`ethereum` Parameters](#ethereum-parameters)
-    - [Ethereum Networks](#ethereum-networks)
+    - [`bitcoin` Parameters](#bitcoin-parameters)
+        - [Bitcoin Networks](#bitcoin-networks)
+    - [`ethereum` Parameters](#ethereum-parameters)
+        - [Ethereum Networks](#ethereum-networks)
 - [Assets](#assets)
-  - [`bitcoin` Parameters](#bitcoin-parameters-1)
-  - [`ether` Parameters](#ether-parameters)
-  - [`erc20` Parameters](#erc20-parameters)
+    - [`bitcoin` Parameters](#bitcoin-parameters-1)
+    - [`ether` Parameters](#ether-parameters)
+    - [`erc20` Parameters](#erc20-parameters)
 - [Protocols](#protocols)
 - [Negotiation Errors](#negotiation-errors)
-  - [Details of the `timeouts-too-tight` error](#details-of-the-timeouts-too-tight-error)
 - [Identities](#identities)
 - [Hash Functions](#hash-functions)
-- [Headers](#headers)
+- [Request types](#request-types)
+    - [SWAP](#swap)
 
 ## Description
 
@@ -104,19 +104,13 @@ The following is a list of protocols defined in COMIT RFCs for use in the `proto
 
 The following is a list of errors that receivers of a SWAP REQUEST may choose to send back to the sender. In order to send a negotiation error, the value of the `negotiation_result` header MUST be set to "failed".
 
-| `reason`               | Reference                          | Description                                                                                                                                                              | `details`                                           |
-| :--------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
-| `unsatisfactory-rate`  | [RFC-002](./RFC-002-SWAP.md)       | The rate of `alpha_asset` to `beta_asset` is not satisfactory to the receiver.                                                                                           | None                                                |
-| `protocol-unsupported` | [RFC-002](./RFC-002-SWAP.md)       | The protocol specified in the `protocol` header is not known to the receiving party.                                                                                     | None                                                |
-| `unknown-ledger`       | [RFC-002](./RFC-002-SWAP.md)       | A ledger referenced by the sending party is unknown to the receiving party.                                                                                              | None                                                |
-| `unknown-asset`        | [RFC-002](./RFC-002-SWAP.md)       | An asset referenced by the sending party is unknown to the receiving party.                                                                                              | None                                                |
-| `timeouts-too-tight`   | [RFC-003](./RFC-003-SWAP-Basic.md) | This indicates to the sender that the difference between `alpha_expiry` and `beta_expiry` is too small and the receiver may accept the swap if they are given more time. | [Details](#details-of-the-timeouts-too-tight-error) |
-
-### Details of the `timeouts-too-tight` error
-
-| property name | type   | description                                                                         |
-| :------------ | :----- | :---------------------------------------------------------------------------------- |
-| min_time      | number | The minimum time difference between the HLTCs in seconds that the receiver requires |
+| `reason`               | Reference                          | Description                                                                                                                                                              |
+| :--------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `unsatisfactory-rate`  | [RFC-002](./RFC-002-SWAP.md)       | The rate of `alpha_asset` to `beta_asset` is not satisfactory to the receiver.                                                                                           |
+| `protocol-unsupported` | [RFC-002](./RFC-002-SWAP.md)       | The protocol specified in the `protocol` header is not known to the receiving party.                                                                                     |
+| `unknown-ledger`       | [RFC-002](./RFC-002-SWAP.md)       | A ledger referenced by the sending party is unknown to the receiving party.                                                                                              |
+| `unknown-asset`        | [RFC-002](./RFC-002-SWAP.md)       | An asset referenced by the sending party is unknown to the receiving party.                                                                                              |
+| `timeouts-too-tight`   | [RFC-003](./RFC-003-SWAP-Basic.md) | This indicates to the sender that the difference between `alpha_expiry` and `beta_expiry` is too small and the receiver may accept the swap if they are given more time. |
 
 ## Identities
 
@@ -135,13 +129,19 @@ The following is a list of cryptographic hash functions for use within COMIT pro
 | :-------- | :------------------------------------------------------------- |
 | `SHA-256` | [IETF RFC463](https://tools.ietf.org/html/rfc4634#section-4.1) |
 
-## Headers
+## Request types
 
-| Name                 | Reference                    | `value`                     |
-| :------------------- | :--------------------------- | :-------------------------- |
-| `alpha_ledger`       | [RFC-002](./RFC-002-SWAP.md) | See [Ledgers](#ledgers)     |
-| `beta_ledger`        | [RFC-002](./RFC-002-SWAP.md) | See [Ledgers](#ledgers)     |
-| `alpha_asset`        | [RFC-002](./RFC-002-SWAP.md) | See [Assets](#assets)       |
-| `beta_asset`         | [RFC-002](./RFC-002-SWAP.md) | See [Assets](#assets)       |
-| `protocol`           | [RFC-002](./RFC-002-SWAP.md) | See [Protocols](#protocols) |
-| `negotiation_result` | [RFC-002](./RFC-002-SWAP.md) | `"successful" OR "failed"`  |
+### SWAP
+
+Introduced in [RFC-002](./RFC-002-SWAP.md).
+
+A SWAP request and the accroding response allow for the following headers to appear:
+
+- `alpha_ledger`
+- `beta_ledger`
+- `alpha_asset`
+- `beta_asset`
+- `protocol`
+- `negotiation_result`
+
+Please refer to [RFC-002](./RFC-002-SWAP.md) for the exact definition of those headers.

--- a/registry.md
+++ b/registry.md
@@ -3,64 +3,60 @@
 **Table of contents**
 - [Description](#description)
 - [Ledgers](#ledgers)
-    - [`bitcoin` Parameters](#bitcoin-parameters)
-        - [Bitcoin Networks](#bitcoin-networks)
-    - [`ethereum` Parameters](#ethereum-parameters)
-        - [Ethereum Networks](#ethereum-networks)
+  - [`bitcoin` Parameters](#bitcoin-parameters)
+    - [Bitcoin Networks](#bitcoin-networks)
+  - [`ethereum` Parameters](#ethereum-parameters)
+    - [Ethereum Networks](#ethereum-networks)
 - [Assets](#assets)
-    - [`bitcoin` Parameters](#bitcoin-parameters-1)
-    - [`ether` Parameters](#ether-parameters)
-    - [`erc20` Parameters](#erc20-parameters)
+  - [`bitcoin` Parameters](#bitcoin-parameters-1)
+  - [`ether` Parameters](#ether-parameters)
+  - [`erc20` Parameters](#erc20-parameters)
 - [Protocols](#protocols)
 - [Negotiation Errors](#negotiation-errors)
-    - [Details of the `timeouts-too-tight` error](#details-of-the-timeouts-too-tight-error)
+  - [Details of the `timeouts-too-tight` error](#details-of-the-timeouts-too-tight-error)
 - [Identities](#identities)
 - [Hash Functions](#hash-functions)
 - [Headers](#headers)
 
 ## Description
 
-This registry defines all types used across COMIT RFCs.
-This registry may be expanded with new RFCs.
+This registry defines all types used across COMIT RFCs. This registry may be expanded with new RFCs.
 
 ## Ledgers
 
 The following is a list of possible values a `Ledger` type header can take:
 
-| Value      | Reference                            | Description                            |
-|:-----------|--------------------------------------|----------------------------------------|
-| `bitcoin`  | [RFC-004](./RFC-004-Bitcoin.md) | The Bitcoin Core family of blockchains |
-| `ethereum` | [RFC-006](./RFC-006-Ethereum.md)| A blockchain following the Ethereum consensus rules     |
-
+| Value      | Reference                        | Description                                         |
+| :--------- | -------------------------------- | --------------------------------------------------- |
+| `bitcoin`  | [RFC-004](./RFC-004-Bitcoin.md)  | The Bitcoin Core family of blockchains              |
+| `ethereum` | [RFC-006](./RFC-006-Ethereum.md) | A blockchain following the Ethereum consensus rules |
 
 And the possible parameters they each may have:
 
 ### `bitcoin` Parameters
 
-| Parameter | Value Type                                  | Description                              |
-|:----------|---------------------------------------------|------------------------------------------|
+| Parameter | Value Type                                | Description                              |
+| :-------- | ----------------------------------------- | ---------------------------------------- |
 | `network` | see [Bitcoin Networks](#bitcoin-networks) | The particular blockchain network to use |
 
 #### Bitcoin Networks
 
 | Value     | Description                          |
-|:----------|:-------------------------------------|
+| :-------- | :----------------------------------- |
 | `regtest` | Private Bitcoin Core regtest network |
 | `testnet` | Bitcoin Core testnet                 |
 | `mainnet` | Bitcoin Core mainnet                 |
 
-
 ### `ethereum` Parameters
 
-| Parameter | Value Type                                    | Description                              |
-|:----------|-----------------------------------------------|------------------------------------------|
+| Parameter | Value Type                                  | Description                              |
+| :-------- | ------------------------------------------- | ---------------------------------------- |
 | `network` | see [Ethereum Networks](#ethereum-networks) | The particular blockchain network to use |
-
 
 #### Ethereum Networks
 
 | Value     | Description                          |
-|:----------|:-------------------------------------|
+| :-------- | :----------------------------------- |
 | `regtest` | Private Ethereum development network |
 | `ropsten` | Ropsten testnet                      |
 | `mainnet` | Ethereum mainnet                     |
@@ -69,10 +65,9 @@ And the possible parameters they each may have:
 
 The following is a list of possible values an `Asset` type header can take:
 
-
-| Value     | Reference                            | Description                   |
-|:----------|--------------------------------------|-------------------------------|
-| `bitcoin` | [RFC-004](./RFC-004-Bitcoin.md) | Native Bitcoin network asset  |
+| Value     | Reference                        | Description                   |
+| :-------- | -------------------------------- | ----------------------------- |
+| `bitcoin` | [RFC-004](./RFC-004-Bitcoin.md)  | Native Bitcoin network asset  |
 | `ether`   | [RFC-006](./RFC-006-Ethereum.md) | Native Ethereum network asset |
 | `erc20`   | [RFC-008](./RFC-008-ERC20.md)    | ERC20 token                   |
 
@@ -81,20 +76,19 @@ And the possible parameters they each may have:
 ### `bitcoin` Parameters
 
 | Parameter  | Value Type | Description         |
-|:-----------|------------|---------------------|
+| :--------- | ---------- | ------------------- |
 | `quantity` | `u64`      | Quantity in satoshi |
 
 ### `ether` Parameters
 
 | Parameter  | Value Type | Description     |
-|:-----------|------------|-----------------|
+| :--------- | ---------- | --------------- |
 | `quantity` | `u256`     | Quantity in wei |
-
 
 ### `erc20` Parameters
 
 | Parameter  | Value Type            | Description                                                                 |
-|:-----------|-----------------------|-----------------------------------------------------------------------------|
+| :--------- | --------------------- | --------------------------------------------------------------------------- |
 | `quantity` | `u256`                | The ERC20 contract value to be transferred (not the decimal token quantity) |
 | `address`  | `0x` prefixed address | The address of the ERC20 contract                                           |
 
@@ -102,54 +96,52 @@ And the possible parameters they each may have:
 
 The following is a list of protocols defined in COMIT RFCs for use in the `protocol` header of a SWAP message.
 
-| Value      | Reference                            | Description                            |
-|:-----------|--------------------------------------|----------------------------------------|
+| Value           | Reference                          | Description            |
+| :-------------- | ---------------------------------- | ---------------------- |
 | `comit-rfc-003` | [RFC-003](./RFC-003-SWAP-Basic.md) | Basic HTLC Atomic Swap |
 
 ## Negotiation Errors
 
-The following is a list of errors that receivers of a SWAP REQUEST may choose to send back to the sender.
-In order to send a negotiation error, the value of the `negotiation_result` header MUST be set to "failed".
+The following is a list of errors that receivers of a SWAP REQUEST may choose to send back to the sender. In order to send a negotiation error, the value of the `negotiation_result` header MUST be set to "failed".
 
-| `reason`      | Reference                            | Description                            | `details`
-|:-----------|--------------------------------------|----------------------------------------|---|
-| `unsatisfactory-rate` | [RFC-002](./RFC-002-SWAP.md) | The rate of `alpha_asset` to `beta_asset` is not satisfactory to the receiver. | None |
-| `protocol-unsupported` | [RFC-002](./RFC-002-SWAP.md) | The protocol specified in the `protocol` header is not known to the receiving party. | None |
-| `unknown-ledger` | [RFC-002](./RFC-002-SWAP.md) | A ledger referenced by the sending party is unknown to the receiving party. | None |
-| `unknown-asset` | [RFC-002](./RFC-002-SWAP.md) | An asset referenced by the sending party is unknown to the receiving party. | None |
-| `timeouts-too-tight` | [RFC-003](./RFC-003-SWAP-Basic.md) | This indicates to the sender that the difference between `alpha_expiry` and `beta_expiry` is too small and the receiver may accept the swap if they are given more time. | [Details](#details-of-the-timeouts-too-tight-error) |
+| `reason`               | Reference                          | Description                                                                                                                                                              | `details`                                           |
+| :--------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
+| `unsatisfactory-rate`  | [RFC-002](./RFC-002-SWAP.md)       | The rate of `alpha_asset` to `beta_asset` is not satisfactory to the receiver.                                                                                           | None                                                |
+| `protocol-unsupported` | [RFC-002](./RFC-002-SWAP.md)       | The protocol specified in the `protocol` header is not known to the receiving party.                                                                                     | None                                                |
+| `unknown-ledger`       | [RFC-002](./RFC-002-SWAP.md)       | A ledger referenced by the sending party is unknown to the receiving party.                                                                                              | None                                                |
+| `unknown-asset`        | [RFC-002](./RFC-002-SWAP.md)       | An asset referenced by the sending party is unknown to the receiving party.                                                                                              | None                                                |
+| `timeouts-too-tight`   | [RFC-003](./RFC-003-SWAP-Basic.md) | This indicates to the sender that the difference between `alpha_expiry` and `beta_expiry` is too small and the receiver may accept the swap if they are given more time. | [Details](#details-of-the-timeouts-too-tight-error) |
 
 ### Details of the `timeouts-too-tight` error
 
-|property name|type|description|
-|:---|:---|:---|
-|min_time|number|The minimum time difference between the HLTCs in seconds that the receiver requires|
+| property name | type   | description                                                                         |
+| :------------ | :----- | :---------------------------------------------------------------------------------- |
+| min_time      | number | The minimum time difference between the HLTCs in seconds that the receiver requires |
 
 ## Identities
 
 [RFC003](./RFC-003-SWAP-Basic.md#identity) requires that each ledger has an associated identity:
 
-| Ledger   | Identity Name | JSON Encoding            | Reference                                   | Description                                                                           |
-|:---------|:--------------|:-------------------------|:--------------------------------------------|---------------------------------------------------------------------------------------|
-| Bitcoin  | `pubkeyhash`  | `hex-encoded-bytes (20)` | [RFC-004](./RFC-005-SWAP-Basic-Bitcoin.md)  | The result of applying SHA256 and then RIPEMD160 to a SECP256k1 compressed public key |
-| Ethereum | `address`     | `0x` prefixed address    | [RFC-007](./RFC-007-SWAP-Basic-Ether.md) | An Ethereum Address                                                                   |
+| Ledger   | Identity Name | JSON Encoding            | Reference                                  | Description                                                                           |
+| :------- | :------------ | :----------------------- | :----------------------------------------- | ------------------------------------------------------------------------------------- |
+| Bitcoin  | `pubkeyhash`  | `hex-encoded-bytes (20)` | [RFC-004](./RFC-005-SWAP-Basic-Bitcoin.md) | The result of applying SHA256 and then RIPEMD160 to a SECP256k1 compressed public key |
+| Ethereum | `address`     | `0x` prefixed address    | [RFC-007](./RFC-007-SWAP-Basic-Ether.md)   | An Ethereum Address                                                                   |
 
 ## Hash Functions
 
 The following is a list of cryptographic hash functions for use within COMIT protocols:
 
-
-| Name    | Reference  |
-|:------- |:----------- |
-| `SHA-256`| [IETF RFC463](https://tools.ietf.org/html/rfc4634#section-4.1) |
+| Name      | Reference                                                      |
+| :-------- | :------------------------------------------------------------- |
+| `SHA-256` | [IETF RFC463](https://tools.ietf.org/html/rfc4634#section-4.1) |
 
 ## Headers
 
- | Name | Reference | `value` |
- |:---|:--- |:--- |
- | `alpha_ledger` | [RFC-002](./RFC-002-SWAP.md) | See [Ledgers](#ledgers) |
- | `beta_ledger` | [RFC-002](./RFC-002-SWAP.md) | See [Ledgers](#ledgers) |
- | `alpha_asset` | [RFC-002](./RFC-002-SWAP.md) | See [Assets](#assets) |
- | `beta_asset` | [RFC-002](./RFC-002-SWAP.md) | See [Assets](#assets) |
- | `protocol` | [RFC-002](./RFC-002-SWAP.md) | See [Protocols](#protocols) |
- | `negotiation_result` | [RFC-002](./RFC-002-SWAP.md) | `"successful" | "failed"` |
+| Name                 | Reference                    | `value`                     |
+| :------------------- | :--------------------------- | :-------------------------- |
+| `alpha_ledger`       | [RFC-002](./RFC-002-SWAP.md) | See [Ledgers](#ledgers)     |
+| `beta_ledger`        | [RFC-002](./RFC-002-SWAP.md) | See [Ledgers](#ledgers)     |
+| `alpha_asset`        | [RFC-002](./RFC-002-SWAP.md) | See [Assets](#assets)       |
+| `beta_asset`         | [RFC-002](./RFC-002-SWAP.md) | See [Assets](#assets)       |
+| `protocol`           | [RFC-002](./RFC-002-SWAP.md) | See [Protocols](#protocols) |
+| `negotiation_result` | [RFC-002](./RFC-002-SWAP.md) | `"successful" OR "failed"`  |

--- a/registry.md
+++ b/registry.md
@@ -39,7 +39,7 @@ The following `type`s are defined:
 
 Introduced in [RFC-002](./RFC-002-SWAP.md).
 
-A SWAP request and the accroding response allow for the following headers to appear:
+A SWAP request and the according response allow for the following headers to appear:
 
 - `alpha_ledger`
 - `beta_ledger`

--- a/registry.md
+++ b/registry.md
@@ -11,8 +11,8 @@
     - [`bitcoin` Parameters](#bitcoin-parameters-1)
     - [`ether` Parameters](#ether-parameters)
     - [`erc20` Parameters](#erc20-parameters)
-- [Protocols](#protocols)
-- [Negotiation Errors](#negotiation-errors)
+- [SWAP Protocols](#swap-protocols)
+- [SWAP decline reasons](#swap-decline-reasons)
 - [Identities](#identities)
 - [Hash Functions](#hash-functions)
 - [Request types](#request-types)
@@ -92,7 +92,7 @@ And the possible parameters they each may have:
 | `quantity` | `u256`                | The ERC20 contract value to be transferred (not the decimal token quantity) |
 | `address`  | `0x` prefixed address | The address of the ERC20 contract                                           |
 
-## Protocols
+## SWAP Protocols
 
 The following is a list of protocols defined in COMIT RFCs for use in the `protocol` header of a SWAP message.
 
@@ -100,9 +100,10 @@ The following is a list of protocols defined in COMIT RFCs for use in the `proto
 | :-------------- | ---------------------------------- | ---------------------- |
 | `comit-rfc-003` | [RFC-003](./RFC-003-SWAP-Basic.md) | Basic HTLC Atomic Swap |
 
-## Negotiation Errors
+## SWAP decline reasons
 
-The following is a list of errors that receivers of a SWAP REQUEST may choose to send back to the sender. In order to send a negotiation error, the value of the `negotiation_result` header MUST be set to "failed".
+The following is a list of response bodies that receivers of a SWAP REQUEST may choose to send back to the sender.
+The value of the `decision` header MUST be set to `declined`.
 
 | `reason`               | Reference                          | Description                                                                                                                                                              |
 | :--------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/registry.md
+++ b/registry.md
@@ -13,6 +13,7 @@
     - [`erc20` Parameters](#erc20-parameters)
 - [Protocols](#protocols)
 - [Negotiation Errors](#negotiation-errors)
+    - [Details of the `timeouts-too-tight` error](#details-of-the-timeouts-too-tight-error)
 - [Identities](#identities)
 - [Hash Functions](#hash-functions)
 - [Headers](#headers)
@@ -99,17 +100,30 @@ And the possible parameters they each may have:
 
 ## Protocols
 
-<!-- TODO: Use same table format here -->
-
 The following is a list of protocols defined in COMIT RFCs for use in the `protocol` header of a SWAP message.
 
-| Name                   | Reference                       |
-|:----------------------- |:-------------------------------- |
-| Basic HTLC Atomic Swap | [RFC-003](./RFC-003-SWAP-Basic) |
+| Value      | Reference                            | Description                            |
+|:-----------|--------------------------------------|----------------------------------------|
+| `comit-rfc-003` | [RFC-003](./RFC-003-SWAP-Basic.md) | Basic HTLC Atomic Swap |
 
 ## Negotiation Errors
 
-<!-- TODO: Add negotiation errors here -->
+The following is a list of errors that receivers of a SWAP REQUEST may choose to send back to the sender.
+In order to send a negotiation error, the value of the `negotiation_result` header MUST be set to "failed".
+
+| `reason`      | Reference                            | Description                            | `details`
+|:-----------|--------------------------------------|----------------------------------------|---|
+| `unsatisfactory-rate` | [RFC-002](./RFC-002-SWAP.md) | The rate of `alpha_asset` to `beta_asset` is not satisfactory to the receiver. | None |
+| `protocol-unsupported` | [RFC-002](./RFC-002-SWAP.md) | The protocol specified in the `protocol` header is not known to the receiving party. | None |
+| `unknown-ledger` | [RFC-002](./RFC-002-SWAP.md) | A ledger referenced by the sending party is unknown to the receiving party. | None |
+| `unknown-asset` | [RFC-002](./RFC-002-SWAP.md) | An asset referenced by the sending party is unknown to the receiving party. | None |
+| `timeouts-too-tight` | [RFC-003](./RFC-003-SWAP-Basic.md) | This indicates to the sender that the difference between `alpha_expiry` and `beta_expiry` is too small and the receiver may accept the swap if they are given more time. | [Details](#details-of-the-timeouts-too-tight-error) |
+
+### Details of the `timeouts-too-tight` error
+
+|property name|type|description|
+|:---|:---|:---|
+|min_time|number|The minimum time difference between the HLTCs in seconds that the receiver requires|
 
 ## Identities
 

--- a/registry.md
+++ b/registry.md
@@ -2,9 +2,10 @@
 
 **Table of contents**
 - [Description](#description)
-- [Request types](#request-types)
-    - [SWAP](#swap)
-- [ERROR frame types](#error-frame-types)
+- [FRAME types](#frame-types)
+    - [REQUEST / RESPONSE](#request--response)
+        - [SWAP](#swap)
+    - [ERROR](#error)
 - [Ledgers](#ledgers)
     - [`bitcoin` Parameters](#bitcoin-parameters)
         - [Bitcoin Networks](#bitcoin-networks)
@@ -25,9 +26,16 @@
 This registry defines all types used across COMIT RFCs.
 This registry may be expanded with new RFCs.
 
-## Request types
+## FRAME types
 
-### SWAP
+This section explains all possible FRAME `type`s.
+
+### REQUEST / RESPONSE
+
+Frames of type `REQUEST` have a `type` field.
+The following `type`s are defined:
+
+#### SWAP
 
 Introduced in [RFC-002](./RFC-002-SWAP.md).
 
@@ -42,7 +50,7 @@ A SWAP request and the accroding response allow for the following headers to app
 
 Please refer to [RFC-002](./RFC-002-SWAP.md) for the exact definition of those headers.
 
-## ERROR frame types
+### ERROR
 
 Implementations SHOULD be aware of the following list of ERROR frame types.
 This list can be extended by RFCs, so implementations SHOULD be prepared to receive an ERROR frame that is not listed here.


### PR DESCRIPTION
The changes proposed in this RFC were mainly driven by the need to harmonize who errors are communicated to the other party.
The basic idea is to split errors up into two categories:

1. errors related to lowest layer of the protocol, e.g. BAM

These are now communicated through an ERROR frame and are usually unrecoverable.

2. errors related to a particular message type (like SWAP)

RFC2 now introduces its own header to encode the status information called `negotiation_result`. This keeps the scope of the feature smaller and is thus less awkward to reason about and implement.

Resolves #23.