### PR TITLE
Minor content improvements

### DIFF
--- a/RFC-001-BAM.md
+++ b/RFC-001-BAM.md
@@ -492,7 +492,7 @@ For example, `REQUEST`.
 - Headers should use snake case convention.
 For example, `payment_method`.
 - `REQUEST` types should use all caps convention as well.
-For example: `BUY`.
+For example: `SWAP`.
 
 ### Connection errors / failure cases
 

--- a/RFC-002-SWAP.md
+++ b/RFC-002-SWAP.md
@@ -220,7 +220,7 @@ Subsequent RFCs can refer to this type if they want to define a particular asset
 
 ### The type `SwapProtocol`
 
-A section "Protocols" is added to the registry which tracks all currently defined protocols.
+A section "SWAP Protocols" is added to the registry which tracks all currently defined protocols.
 Subsequent RFCs can refer to this type if they want to define a particular swap protocol.
 
 ### The type `DeclineBody` and the initial set of possible values

--- a/RFC-003-SWAP-Basic.md
+++ b/RFC-003-SWAP-Basic.md
@@ -90,7 +90,7 @@ Additionally, α-HTLC and β-HTLC refer to the HTLCs deployed on the α and β l
 
 ### SWAP Request Header
 
-The protocol begins with one party (the sender) sending a SWAP REQUEST message to another (the receiver) with the `protocol` header's value set to `comit-rfc-003`.
+The protocol begins with one party (the sender, referred to as 'Alice') sending a SWAP REQUEST message to another party (the receiver, referred to as 'Bob') with the `protocol` header's value set to `comit-rfc-003`.
 The header MUST have the following parameters:
 
 #### `hash_function`

--- a/RFC-003-SWAP-Basic.md
+++ b/RFC-003-SWAP-Basic.md
@@ -69,8 +69,7 @@ Absolute time locks are necessary because the protocol is only secure if the exp
 *Relative time lock* HTLCs have an expiration time that is relative to their inclusion in the ledger.
 In this protocol, they would allow an attacker to manipulate the relative expiration times of the HTLCs if they are able to delay the inclusion of a HTLC onto one of the ledgers.
 
-HTLCs MUST enforce the length of the secret to be equal to the hash function's output length.
-If this is not enforced, a secret may be able to active the redeem path on one HTLC but not on the other.
+A secret length of 32 bytes is enforced by the HTLCs.
 
 In this RFC, HTLCs are constructed with the following parameters
 

--- a/RFC-003-SWAP-Basic.md
+++ b/RFC-003-SWAP-Basic.md
@@ -69,7 +69,7 @@ Absolute time locks are necessary because the protocol is only secure if the exp
 *Relative time lock* HTLCs have an expiration time that is relative to their inclusion in the ledger.
 In this protocol, they would allow an attacker to manipulate the relative expiration times of the HTLCs if they are able to delay the inclusion of a HTLC onto one of the ledgers.
 
-A secret length of 32 bytes is enforced by the HTLCs.
+A secret length of 32 bytes MUST be enforced by the HTLCs.
 
 In this RFC, HTLCs are constructed with the following parameters
 

--- a/registry.md
+++ b/registry.md
@@ -142,7 +142,7 @@ And the possible parameters they each may have:
 
 ## SWAP Protocols
 
-The following is a list of protocols defined in COMIT RFCs for use in the `protocol` header of a SWAP message.
+The following is a list of protocols defined in COMIT RFCs for use in the `protocol` header of a SWAP message (i.e. a REQUEST message with type SWAP).
 
 | Value           | Reference                          | Description            |
 | :-------------- | ---------------------------------- | ---------------------- |


### PR DESCRIPTION
This PR includes minor improvements to RFCs 1-3.  No API changes, no changes in meaning, just clarification and simplification.

Patch 1 - Use 'SWAP' instead of 'BUY' (make examples as relevant and simple as possible) 
Patch 2 - Use full name of registry section (reduce ambiguity)
Patch 3 - Clarify SwapProtocol registry type (improve clarity)
Patch 4 - Document 32 byte secret length limit (update RFC to match recent bug fix to `comit-rs`
Patch 5 - Link terms sender/receiver with alice/bob (improve clarity)