### PR TITLE
Use 'transfer' instead of 'transport'

### DIFF
--- a/RFC-001-BAM.md
+++ b/RFC-001-BAM.md
@@ -57,7 +57,7 @@ It is a domain-agnostic and self-descriptive protocol and potentially supports m
 
 In COMIT, nodes need to exchange all kinds of information in a peer-to-peer manner.
 As COMIT is an inherently distributed system, the network will eventually become heterogeneous, with an array of implementations, varying in languages and versions.
-Given that, we need a transport protocol that fulfils the following requirements:
+Given that, we need a transfer protocol that fulfils the following requirements:
 
 - **Different kinds of messages:** The protocol needs to support requests (response expected) and one-way transmissions (no response).
 - **Self-descriptive messages:** Because of the heterogeneous nature, the protocol needs to allow the introduction of new features without breaking older versions.


### PR DESCRIPTION
BAM is not a transport protocol, it is an application protocol.  It could also be described as a low level protocol or a transfer protocol. Choose 'transfer' since it is one word and it aptly describes the
protocol.

Use term `transfer protocol` instead of `transport protocol`.

Fixes #83