### PR TITLE
Remove JSON schema description from RFC

### DIFF
--- a/RFC-001-BAM.md
+++ b/RFC-001-BAM.md
@@ -332,42 +332,8 @@ As mentioned, the JSON documents are actually sent over the wire **without** new
 
 #### Frames
 
-Each frame is encoded as a JSON-object with the following schema:
 
-```json
-{
-  "$id": "https://comit.network/transport-protocol/frame.json",
-  "type": "object",
-  "definitions": {},
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "properties": {
-    "type": {
-      "$id": "/properties/type",
-      "type": "string",
-      "title": "The frame type",
-      "default": "",
-      "examples": [
-        "REQUEST"
-      ]
-    },
-    "id": {
-      "$id": "/properties/id",
-      "type": "integer",
-      "title": "The frame id",
-      "default": 0,
-      "examples": [
-        0
-      ],
-      "minimum" : 0,
-      "maximum" : 4294967295
-    },
-    "payload": {
-      "$id": "/properties/payload",
-      "type": "object"
-    }
-  }
-}
-```
+Each frame is encoded as a JSON-object with a `type`, `id` and `payload` field.
 
 Example:
 


### PR DESCRIPTION
While reviewing https://github.com/comit-network/RFCs/pull/87 I noticed that we still have that JSON schema in the RFC.
I would like to remove it because:

1. The object is very simple and can also be described using words.
2. A JSON schema requires a `$id` field and the one we have there is a non-dereferenceable URL. Until that is fixed, I think it is less confusing if we don't have a schema in there.