### PR TITLE
Add 'Expiry Time Considerations' section

### DIFF
--- a/RFC-003-SWAP-Basic.md
+++ b/RFC-003-SWAP-Basic.md
@@ -204,7 +204,7 @@ Beta            |--------------------|
 In order for the swap to be atomic the alpha asset must be redeemed *before* `beta_expiry`.
 To be more precise; the alpha redeem transaction must have been accepted into the alpha ledger before `beta_expiry`.
 This means that the window of time for which atomicity is guaranteed for Alice is actually *smaller* than it at first appears.
-There exists a point on the beta time window depicted above (and again below) after which a redeem transaction may not get included into the ledger before the expiry time, at which time it is possible for Bob to attempt a refund transaction.
+There exists a point on the beta time window depicted above (and again below) after which a redeem transaction by Alice may not get included into the ledger before the expiry time, at which time it is possible for Bob to attempt a refund transaction.
 This point is marked below with `???` because it is dependant on the ledger.
 
 

--- a/RFC-003-SWAP-Basic.md
+++ b/RFC-003-SWAP-Basic.md
@@ -117,6 +117,8 @@ When `comit-rfc-003` is used as the value for `protocol` for a SWAP REQUEST mess
 | `beta_redeem_identity`  | `β::Identity`       | The identity on β that **B** will be transferred to when the β-HTLC is activated with the correct secret |
 | `secret_hash`           | `hex-encoded-bytes` | The output of calling `hash_function` on the secret                                                      |
 
+In order for the protocol to provide atomicity there are constraints on the expiry times, please see 'Expiry Time Considerations' below.
+
 If `alpha_expiry` or `beta_expiry` are in the past, implementations SHOULD consider the request to be invalid.
 
 ### SWAP Response
@@ -182,6 +184,43 @@ Alice then waits until `alpha_expiry` and then MUST activate the refund path of 
 When Bob learns the secret from Alice's redeem activation of β-HTLC he MUST activate the redeem path of α-HTLC and gain ownership of **A**.
 He MUST make sure he does this before `alpha_expiry` or risks both losing **B** and not gaining **A**.
 To activate the redeem path he uses the secret and the procedure defined in the specification of the α-HTLC.
+
+## Expiry Time Considerations
+
+Conceptually there is a time window from when the HTLC is deployed until the HTLC expires and can be refunded.
+The protocol depends on the alpha time window being a superset of the beta time window.
+
+
+  time ->
+
+     deploy                                 expiry
+
+Alpha  |----------------------------------------|
+
+Beta            |--------------------|
+
+             deploy              expiry
+
+In addition, in order for the swap to be atomic the alpha asset must be redeemed *before* `beta_expiry`.
+To be more precise; the alpha redeem transaction must have been accepted into the alpha ledger before `beta_expiry`.
+This means that the window of time for which atomicity is guaranteed for Alice is actually *smaller* than it at first appears.
+There exists a point on the beta time window depicted above (and again below) after which a redeem transaction may not get included into the ledger before the expiry time, at which time it is possible for Bob to attempt a refund transaction.
+This point is marked below with `???` because it is dependant on the ledger.
+
+
+  time ->
+
+     deploy                                 expiry
+
+Alpha  |----------------------------------------|
+
+                                ???
+                                 |
+Beta            |----------------|---|
+                                 |
+
+             deploy              expiry
+
 
 ## Application Considerations
 

--- a/RFC-003-SWAP-Basic.md
+++ b/RFC-003-SWAP-Basic.md
@@ -193,13 +193,13 @@ The protocol depends on the alpha time window being a superset of the beta time 
 ```
   time ->
 
-     deploy                                 expiry
+     deploy                                   expiry
 
 Alpha  |----------------------------------------|
 
 Beta            |--------------------|
 
-             deploy              expiry
+              deploy               expiry
 ```
 
 In order for the swap to be atomic the alpha asset must be redeemed *before* `beta_expiry`.

--- a/RFC-003-SWAP-Basic.md
+++ b/RFC-003-SWAP-Basic.md
@@ -201,7 +201,7 @@ Beta            |--------------------|
 
              deploy              expiry
 
-In addition, in order for the swap to be atomic the alpha asset must be redeemed *before* `beta_expiry`.
+In order for the swap to be atomic the alpha asset must be redeemed *before* `beta_expiry`.
 To be more precise; the alpha redeem transaction must have been accepted into the alpha ledger before `beta_expiry`.
 This means that the window of time for which atomicity is guaranteed for Alice is actually *smaller* than it at first appears.
 There exists a point on the beta time window depicted above (and again below) after which a redeem transaction may not get included into the ledger before the expiry time, at which time it is possible for Bob to attempt a refund transaction.

--- a/RFC-003-SWAP-Basic.md
+++ b/RFC-003-SWAP-Basic.md
@@ -204,23 +204,7 @@ Beta            |--------------------|
 In order for the swap to be atomic the alpha asset must be redeemed *before* `beta_expiry`.
 To be more precise; the alpha redeem transaction must have been accepted into the alpha ledger before `beta_expiry`.
 This means that the window of time for which atomicity is guaranteed for Alice is actually *smaller* than it at first appears.
-There exists a point on the beta time window depicted above (and again below) after which a redeem transaction by Alice may not get included into the ledger before the expiry time, at which time it is possible for Bob to attempt a refund transaction.
-This point is marked below with `???` because it is dependant on the ledger.
-
-
-  time ->
-
-     deploy                                 expiry
-
-Alpha  |----------------------------------------|
-
-                                ???
-                                 |
-Beta            |----------------|---|
-                                 |
-
-             deploy              expiry
-
+There exists a point on the beta time window depicted above after which a redeem transaction by Alice may not get included into the ledger before the expiry time, at which time it is possible for Bob to attempt a refund transaction.
 
 ## Application Considerations
 

--- a/RFC-003-SWAP-Basic.md
+++ b/RFC-003-SWAP-Basic.md
@@ -190,7 +190,7 @@ To activate the redeem path he uses the secret and the procedure defined in the 
 Conceptually there is a time window from when the HTLC is deployed until the HTLC expires and can be refunded.
 The protocol depends on the alpha time window being a superset of the beta time window.
 
-
+```
   time ->
 
      deploy                                 expiry
@@ -200,6 +200,7 @@ Alpha  |----------------------------------------|
 Beta            |--------------------|
 
              deploy              expiry
+```
 
 In order for the swap to be atomic the alpha asset must be redeemed *before* `beta_expiry`.
 To be more precise; the alpha redeem transaction must have been accepted into the alpha ledger before `beta_expiry`.


### PR DESCRIPTION
The HTLC expiry time requirements for rfc003 are not fully explained.

Add a section titled 'Expiry Time Considerations' that makes an attempt at
better explaining the expiry time requirements for atomicity to be guaranteed
when using rfc003.