### PR TITLE
Update stale header

### DIFF
--- a/RFC-003-SWAP-Basic.md
+++ b/RFC-003-SWAP-Basic.md
@@ -123,7 +123,7 @@ If `alpha_expiry` or `beta_expiry` are in the past, implementations SHOULD consi
 
 ### SWAP Response
 
-If responding with `successful` for the `negotiation_result` header, the responder MUST include the following fields in the response body:
+If responding with `accepted` for the `decision` header, the responder MUST include the following fields in the response body:
 
 | Name                    | JSON Encoding | Description                                                                                              |
 | ----------------------- | ------------- | -------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Currently header is named 'negotiation_result'.  This header no longer exists
(assuming it did exist).  The value is also stale.

Update stale header negotiation_result -> decision.
Update stale header value 'successful' -> accepted.