### PR TITLE
Convert RFC002 from markdown to AsciiDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ If you want to get involved, make sure to read [RFC-000](./RFC-000-Process-descr
 
 - [000: RFC-Process description](./RFC-000-Process-description.md)
 - [001: COMIT messaging protocol](./RFC-001-libp2p.adoc)
-- [002: SWAP Message Types](./RFC-002-SWAP.md)
+- [002: SWAP Message Types](./RFC-002-SWAP.adoc)
 - [003: Basic HTLC Atomic Swap](./RFC-003-SWAP-Basic.md)
 - [004: The Bitcoin Ledger](./RFC-004-Bitcoin.md)
 - [005: Bitcoin Basic HTLC Atomic Swap](./RFC-005-SWAP-Basic-Bitcoin.adoc)

--- a/RFC-002-SWAP.adoc
+++ b/RFC-002-SWAP.adoc
@@ -1,64 +1,36 @@
-# SWAP Message Types
+= SWAP message
+:toc:
+:revdate: 2018-12-28
+:numbered:
+:sectnumlevels: 5
 
-- RFC-Number: 002
-- Status: Draft
-- Discussion issue: [#18](https://github.com/comit-network/RFCs/issues/18)
-- Created on: 28 Dec. 2018
+NOTE: RFC-Number: 002 +
+Status: Draft +
+Discussion-issue: https://github.com/comit-network/RFCs/issues/18[#18] +
++ Created on: {revdate} +
 
-**Table of contents**
-- [Introduction](#introduction)
-- [Terminology](#terminology)
-    - [Ledger](#ledger)
-    - [Asset](#asset)
-    - [Alpha and Beta](#alpha-and-beta)
-- [BAM! messages](#bam-messages)
-    - [SWAP REQUEST frame](#swap-request-frame)
-        - [Definition](#definition)
-        - [Headers](#headers)
-        - [Body](#body)
-    - [SWAP RESPONSE frame](#swap-response-frame)
-        - [Definition](#definition-1)
-        - [Headers](#headers-1)
-        - [Body](#body-1)
-- [Examples](#examples)
-    - [SWAP REQUEST frame](#swap-request-frame-1)
-    - [SWAP RESPONSE frame](#swap-response-frame-1)
-        - [Accepted SWAP REQUEST](#accepted-swap-request)
-        - [Declined SWAP REQUEST](#declined-swap-request)
-- [Registry extensions](#registry-extensions)
-    - [The type `Ledger`](#the-type-ledger)
-    - [The type `Asset`](#the-type-asset)
-    - [The type `SwapProtocol`](#the-type-swapprotocol)
-    - [The type `DeclineBody` and the initial set of possible values](#the-type-declinebody-and-the-initial-set-of-possible-values)
-        - [`unsatisfactory-rate`](#unsatisfactory-rate)
-            - [`details`](#details)
-        - [`protocol-unsupported`](#protocol-unsupported)
-            - [`details`](#details-1)
-        - [`unknown-ledger`](#unknown-ledger)
-            - [`details`](#details-2)
-        - [`unknown-asset`](#unknown-asset)
-            - [`details`](#details-3)
-
-## Introduction
+== Description
 
 This RFC serves two purposes:
 
 1. Introduce terminology used to describe the exchange of assets.
 2. Define a REQUEST/RESPONSE message pair for two parties to negotiate such an exchange via `BAM!`.
 
-## Terminology
+== Content
+
+=== Terminology
 
 To describe the elements of an exchange, we use the terms `Ledger`, `Asset`, `Alpha` and `Beta`.
 
-### Ledger
+==== Ledger
 
 A ledger is anything that records ownership and allows transferal of that ownership.
 
-### Asset
+==== Asset
 
 An asset is anything whose ownership can be transferred on a [ledger](#ledger).
 
-### Alpha and Beta
+==== Alpha and Beta
 
 The terms **alpha** and **beta** are used to unambiguously identify assets and ledgers in an exchange.
 Such an exchange can thus be described as:
@@ -71,48 +43,66 @@ This terminology has several advantages:
 1. It does not imply an order (compared to a terminology like **first**/**second**).
 2. It is not subjective to any of the parties (compared to terminology like **source**/**target**, **incoming**/**outgoing** or **local**/**remote**).
 
-## BAM! messages
+=== Messages
 
 The messages to negotiate such an exchange consist of a `REQUEST` frame and a corresponding `RESPONSE` frame.
 
-### SWAP REQUEST frame
+==== SWAP REQUEST frame
 
-#### Definition
+===== Definition
 
 A SWAP REQUEST message is a `FRAME` of type `REQUEST`.
-[As per definition](RFC-001-libp2p.adoc#_frame_types) in `RFC001`, a `REQUEST` `FRAME` has a `type` that defines its semantics.
+link:./RFC-001-libp2p.adoc#frame-types[As per definition] in `RFC001`, a `REQUEST` `FRAME` has a `type` that defines its semantics.
 For the SWAP REQUEST message, this type is `SWAP`.
 
-#### Headers
+===== Headers
 
 To express all the information for an exchange, a SWAP REQUEST MUST include the following headers:
 
-| Header         | Value (Link to registry section)                                                         | Description                                                          |
-| -------------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| `alpha_ledger` | [Ledger](https://github.com/comit-network/RFCs/blob/master/registry.md#ledgers)          | The ledger the alpha-asset is tracked on.                            |
-| `beta_ledger`  | [Ledger](https://github.com/comit-network/RFCs/blob/master/registry.md#ledgers)          | The ledger the beta-asset is tracked on.                             |
-| `alpha_asset`  | [Asset](https://github.com/comit-network/RFCs/blob/master/registry.md#assets)            | The asset whose ownership will be transferred on the `alpha_ledger`. |
-| `beta_asset`   | [Asset](https://github.com/comit-network/RFCs/blob/master/registry.md#assets)            | The asset whose ownership will be transferred on the `beta_ledger`.  |
-| `protocol`     | [SWAP Protocol](https://github.com/comit-network/RFCs/blob/master/registry.md#protocols) | The protocol that is used to transfer the ownership of the assets.   |
+.Valid headers with a SWAP request
+|===
+|Header |Value (Link to registry section) |Description
+
+|`alpha_ledger`
+|https://github.com/comit-network/RFCs/blob/master/registry.md#ledgers[Ledger]
+|The ledger the alpha-asset is tracked on.
+
+|`beta_ledger`
+|https://github.com/comit-network/RFCs/blob/master/registry.md#ledgers[Ledger]
+|The ledger the beta-asset is tracked on.
+
+|`alpha_asset`
+|https://github.com/comit-network/RFCs/blob/master/registry.md#assets[Asset]
+|The asset whose ownership will be transferred on the `alpha_ledger`.
+
+|`beta_asset`
+|https://github.com/comit-network/RFCs/blob/master/registry.md#assets[Asset]
+|The asset whose ownership will be transferred on the `beta_ledger`.
+
+|`protocol`
+|https://github.com/comit-network/RFCs/blob/master/registry.md#protocols[SWAP Protocol]
+|The protocol that is used to transfer the ownership of the assets.
+
+|===
 
 This RFC only defines these headers.
 The actual definition of ledgers, assets and protocols is not subject to this RFC.
 
-#### Body
+===== Body
 
 The body of a SWAP REQUEST depends on the chosen `protocol`.
 It is therefore subject to RFCs which define such protocols to also define which information is contained in the `body` of a SWAP REQUEST/RESPONSE frame.
 
-### SWAP RESPONSE frame
+==== SWAP RESPONSE frame
 
-#### Definition
+===== Definition
 
 A frame of type `REQUEST` implies a `RESPONSE`.
 We will refer to the response of a SWAP REQUEST as SWAP RESPONSE.
 
 A SWAP RESPONSE contains the decision made by the other peer.
 
-#### Headers
+===== Headers
 
 The response MUST contain the `decision` header.
 
@@ -121,28 +111,29 @@ The `decision` header is defined as follows:
 - `value`: `accepted` OR `declined`.
 - `parameters`: None
 
-#### Body
+===== Body
 
 The content of the `body` depends on the values of the headers.
 The following diagram illustrates the process:
 
-![Decision diagram for parsing the SWAP RESPONSE body](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/comit-network/RFCs/master/assets/RFC002-parse-response-body.puml&cache=no)
+image::http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/comit-network/RFCs/master/assets/RFC002-parse-response-body.puml&cache=no[Decision diagram for parsing the SWAP RESPONSE body]
 
 The `DeclineBody` is an object with two properties:
 
 - `reason`: An identifying string that briefly describes why the request was declined.
 - `details`: An object containing further, relevant details. The object-shape depends on the given `reason`.
 
-See the [Registry extensions](#registry-extensions)-section for examples of a `DeclineBody`.
+See the <<Registry extensions>>-section for examples of a `DeclineBody`.
 
-## Examples
+=== Examples
 
 This section contains examples of SWAP REQUEST/RESPONSE frames.
 Elements not relevant for this RFC or which are subject to later definition are filled in with "...".
 
-### SWAP REQUEST frame
+==== SWAP REQUEST frame
 
-```json
+[source,json]
+----
 {
   "type": "REQUEST",
   "id": 0,
@@ -168,15 +159,16 @@ Elements not relevant for this RFC or which are subject to later definition are 
       "protocol": "...",
     },
     "body": { ... },
-  } 
+  }
 }
-```
+----
 
-### SWAP RESPONSE frame
+==== SWAP RESPONSE frame
 
-#### Accepted SWAP REQUEST
+===== Accepted SWAP REQUEST
 
-```json
+[source,json]
+----
 {
   "type": "RESPONSE",
   "id": 0,
@@ -187,11 +179,12 @@ Elements not relevant for this RFC or which are subject to later definition are 
     "body": { ... },
   }
 }
-```
+----
 
-#### Declined SWAP REQUEST
+===== Declined SWAP REQUEST
 
-```json
+[source,json]
+----
 {
   "type": "RESPONSE",
   "id": 0,
@@ -202,28 +195,28 @@ Elements not relevant for this RFC or which are subject to later definition are 
     "body": { ... },
   }
 }
-```
+----
 
-## Registry extensions
+== Registry extensions
 
 This RFC extends the registry with the following elements:
 
-### The type `Ledger`
+=== The type `Ledger`
 
 A section "Ledgers" is added to the registry which tracks all currently defined ledger types.
 Subsequent RFCs can refer to this type if they want to define a particular ledger.
 
-### The type `Asset`
+=== The type `Asset`
 
 A section "Assets" is added to the registry which tracks all currently defined asset types.
 Subsequent RFCs can refer to this type if they want to define a particular asset.
 
-### The type `SwapProtocol`
+=== The type `SwapProtocol`
 
 A section "SWAP Protocols" is added to the registry which tracks all currently defined protocols.
 Subsequent RFCs can refer to this type if they want to define a particular swap protocol.
 
-### The type `DeclineBody` and the initial set of possible values
+=== The type `DeclineBody` and the initial set of possible values
 
 A section "DeclineBody" is added to the registry which tracks all currently defined reasons.
 Subsequent RFCs can refer to this type if they want to define new reasons for declining SWAP REQUESTs.
@@ -231,36 +224,36 @@ Subsequent RFCs can refer to this type if they want to define new reasons for de
 The following `DeclineBody`s are added to the list.
 Each heading represents a `reason`.
 
-#### `unsatisfactory-rate`
+==== `unsatisfactory-rate`
 
 The rate of `alpha_asset` to `beta_asset` is not satisfactory to the receiver.
 
-##### `details`
+===== `details`
 
 TBD 
 
-#### `protocol-unsupported`
+==== `protocol-unsupported`
 
 The protocol specified in the `protocol` header is not known to the receiving party.
 
-##### `details`
+===== `details`
 
 TBD <!-- List known protocols in details -->
 
-#### `unknown-ledger`
+==== `unknown-ledger`
 
 A ledger referenced by the sending party is unknown to the receiving party.
 Note that different networks of the same blockchain are different ledgers!
 Bitcoin Testnet is a different ledger than Bitcoin Mainnet.
 
-##### `details`
+===== `details`
 
 TBD <!-- List known ledgers in details -->
 
-#### `unknown-asset`
+==== `unknown-asset`
 
 An asset referenced by the sending party is unknown to the receiving party.
 
-##### `details`
+===== `details`
 
 TBD <!-- List known assets in details -->

--- a/RFC-002-SWAP.adoc
+++ b/RFC-002-SWAP.adoc
@@ -14,7 +14,7 @@ Discussion-issue: https://github.com/comit-network/RFCs/issues/18[#18] +
 This RFC serves two purposes:
 
 1. Introduce terminology used to describe the exchange of assets.
-2. Define a REQUEST/RESPONSE message pair for two parties to negotiate such an exchange via `BAM!`.
+2. Define a REQUEST/RESPONSE message pair for two parties to negotiate such an exchange via the COMIT messaging protocol.
 
 == Content
 

--- a/RFC-003-SWAP-Basic.md
+++ b/RFC-003-SWAP-Basic.md
@@ -37,7 +37,7 @@
 
 ## Description
 
-This RFC describes a basic atomic swap protocol and the related parameters required to use it as a COMIT [RFC002](./RFC-002-SWAP.md#protocol) SWAP protocol.
+This RFC describes a basic atomic swap protocol and the related parameters required to use it as a COMIT [RFC002](RFC-002-SWAP.adoc#protocol) SWAP protocol.
 It uses Hash Time Locked Contracts to swap ownership of two assets on different ledgers between two parties.
 It is a simplified version of the protocol originally described by TierNolan[¹](#references).
 A detailed sequence diagram showing the content of this RFC can be found in the appendix section [Sequence Diagram](#sequence-diagram).
@@ -87,7 +87,7 @@ How to construct an HTLC for each ledger will be defined in subsequent RFCs.
 
 ## Setup Phase
 
-In the setup phase the two parties exchange [RFC002](./RFC-002-SWAP.md) SWAP messages to negotiate the parameters of the HTLCs.
+In the setup phase the two parties exchange [RFC002](RFC-002-SWAP.adoc) SWAP messages to negotiate the parameters of the HTLCs.
 The values α, β, **A** and **B** used below refer to the ledgers and assets described by the SWAP headers `alpha_ledger`, `beta_ledger`, `alpha_asset` and `beta_asset` respectively.
 Additionally, α-HTLC and β-HTLC refer to the HTLCs deployed on the α and β ledgers.
 

--- a/RFC-004-Bitcoin.md
+++ b/RFC-004-Bitcoin.md
@@ -21,7 +21,7 @@
 
 This RFC specifies how the Bitcoin blockchain and its native asset Bitcoin are described in Ledger and Asset type headers within the COMIT protocol.
 Bitcoin refers specifically to [Bitcoin Core](https://github.com/bitcoin/bitcoin/) and not any blockchains derived from it.
-The Ledger and Asset type headers were introduced in [RFC002](./RFC-002-SWAP.md) to describe assets being exchanged in a COMIT SWAP protocol.
+The Ledger and Asset type headers were introduced in [RFC002](RFC-002-SWAP.adoc) to describe assets being exchanged in a COMIT SWAP protocol.
 
 ## The Bitcoin Ledger
 
@@ -96,7 +96,7 @@ And defines the `quantity` parameter for it:
 
 ## SWAP Request
 
-The following shows an example [RFC002](./RFC-002-SWAP.md) SWAP REQUEST with Bitcoin as the `alpha_ledger` and 1 Bitcoin as the `alpha_asset`.
+The following shows an example [RFC002](RFC-002-SWAP.adoc) SWAP REQUEST with Bitcoin as the `alpha_ledger` and 1 Bitcoin as the `alpha_asset`.
 Fields that are outside of the scope of this RFC are filled with `...`.
 
 ``` json

--- a/RFC-006-Ethereum.md
+++ b/RFC-006-Ethereum.md
@@ -20,7 +20,7 @@
 
 This RFC specifies how the Ethereum blockchain and its native asset Ether are described in Ledger and Asset type headers within the COMIT protocol.
 *Ethereum* refers specifically to the blockchain endorsed by [The Ethereum Foundation](https://www.ethereum.org/foundation) and its associated testnets but not any other blockchains related to or derived from it.
-The Ledger and Asset type headers were introduced in [RFC002](./RFC-002-SWAP.md) to describe assets being exchanged in a COMIT SWAP protocol.
+The Ledger and Asset type headers were introduced in [RFC002](RFC-002-SWAP.adoc) to describe assets being exchanged in a COMIT SWAP protocol.
 
 ## The Ethereum Ledger
 
@@ -96,7 +96,7 @@ And defines the `quantity` parameter for it:
 
 # Examples
 
-The following shows an example [RFC002](./RFC-002-SWAP.md) SWAP REQUEST with Ethereum as the `alpha_ledger` and 1 Ether as the `alpha_asset`.
+The following shows an example [RFC002](RFC-002-SWAP.adoc) SWAP REQUEST with Ethereum as the `alpha_ledger` and 1 Ether as the `alpha_asset`.
 Fields that are outside of the scope of this RFC are filled with `...`.
 
 ``` json

--- a/RFC-008-ERC20.md
+++ b/RFC-008-ERC20.md
@@ -16,7 +16,7 @@
 
 This RFC defines how Ethereum based [ERC20](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md) tokens should be described in Asset type headers.
 
-The Asset type header was introduced in [RFC002](./RFC-002-SWAP.md) to describe assets being exchanged in a COMIT SWAP protocol.
+The Asset type header was introduced in [RFC002](RFC-002-SWAP.adoc) to describe assets being exchanged in a COMIT SWAP protocol.
 
 ## The ERC20 Asset
 
@@ -63,7 +63,7 @@ And defines its parameters:
 
 # Examples
 
-The following shows an example [RFC002](./RFC-002-SWAP.md) SWAP REQUEST with Ethereum as the `alpha_ledger` and 1 [PAY token](https://etherscan.io/token/0xB97048628DB6B661D4C2aA833e95Dbe1A905B280) as the `alpha_asset`.
+The following shows an example [RFC002](RFC-002-SWAP.adoc) SWAP REQUEST with Ethereum as the `alpha_ledger` and 1 [PAY token](https://etherscan.io/token/0xB97048628DB6B661D4C2aA833e95Dbe1A905B280) as the `alpha_asset`.
 Fields that are outside of the scope of this RFC are filled with `...`.
 
 ``` json

--- a/RFC-010-Omni-Layer.md
+++ b/RFC-010-Omni-Layer.md
@@ -19,7 +19,7 @@
 This RFC defines how Bitcoin-based Omni Layer Assets are described in Asset type headers.
 Omni Layer refers specifically to the [Omni Layer Protocol](https://github.com/OmniLayer/spec).
 
-The Asset type header was introduced in [RFC002](./RFC-002-SWAP.md) to describe assets being exchanged in a COMIT SWAP protocol.
+The Asset type header was introduced in [RFC002](RFC-002-SWAP.adoc) to describe assets being exchanged in a COMIT SWAP protocol.
 
 ## The Omni Layer Assets
 
@@ -109,7 +109,7 @@ And defines its parameters:
 
 ## Examples
 
-The following shows an example [RFC002](./RFC-002-SWAP.md) SWAP REQUEST with Bitcoin as the `alpha_ledger` and 1 [Omni Layer asset TetherUS](https://www.omniexplorer.info/asset/31) as the `alpha_asset`.
+The following shows an example [RFC002](RFC-002-SWAP.adoc) SWAP REQUEST with Bitcoin as the `alpha_ledger` and 1 [Omni Layer asset TetherUS](https://www.omniexplorer.info/asset/31) as the `alpha_asset`.
 Fields that are outside of the scope of this RFC are filled with `...`.
 Note: TetherUS is divisible.
 

--- a/registry.md
+++ b/registry.md
@@ -36,7 +36,7 @@ The following `type`s are defined:
 
 #### SWAP
 
-Introduced in [RFC-002](./RFC-002-SWAP.md).
+Introduced in [RFC-002](RFC-002-SWAP.adoc).
 
 A SWAP request and the according response allow for the following headers to appear:
 
@@ -47,7 +47,7 @@ A SWAP request and the according response allow for the following headers to app
 - `protocol`
 - `decision`
 
-Please refer to [RFC-002](./RFC-002-SWAP.md) for the exact definition of those headers.
+Please refer to [RFC-002](RFC-002-SWAP.adoc) for the exact definition of those headers.
 
 ## Ledgers
 
@@ -142,10 +142,10 @@ The value of the `decision` header MUST be set to `declined`.
 
 | `reason`               | Reference                          | Description                                                                                                                                                              |
 | :--------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `unsatisfactory-rate`  | [RFC-002](./RFC-002-SWAP.md)       | The rate of `alpha_asset` to `beta_asset` is not satisfactory to the receiver.                                                                                           |
-| `protocol-unsupported` | [RFC-002](./RFC-002-SWAP.md)       | The protocol specified in the `protocol` header is not known to the receiving party.                                                                                     |
-| `unknown-ledger`       | [RFC-002](./RFC-002-SWAP.md)       | A ledger referenced by the sending party is unknown to the receiving party.                                                                                              |
-| `unknown-asset`        | [RFC-002](./RFC-002-SWAP.md)       | An asset referenced by the sending party is unknown to the receiving party.                                                                                              |
+| `unsatisfactory-rate`  | [RFC-002](RFC-002-SWAP.adoc)       | The rate of `alpha_asset` to `beta_asset` is not satisfactory to the receiver.                                                                                           |
+| `protocol-unsupported` | [RFC-002](RFC-002-SWAP.adoc)       | The protocol specified in the `protocol` header is not known to the receiving party.                                                                                     |
+| `unknown-ledger`       | [RFC-002](RFC-002-SWAP.adoc)       | A ledger referenced by the sending party is unknown to the receiving party.                                                                                              |
+| `unknown-asset`        | [RFC-002](RFC-002-SWAP.adoc)       | An asset referenced by the sending party is unknown to the receiving party.                                                                                              |
 | `timeouts-too-tight`   | [RFC-003](./RFC-003-SWAP-Basic.md) | This indicates to the sender that the difference between `alpha_expiry` and `beta_expiry` is too small and the receiver may accept the swap if they are given more time. |
 
 ## Identities


### PR DESCRIPTION
Follow-up patch after #92 to remove mentions of BAM from RFC002.

First patch converts it to AsciiDoc.
Second patch removes the mention of BAM.